### PR TITLE
added default equality operators to number range filter

### DIFF
--- a/Filter/Extension/Type/NumberRangeFilterType.php
+++ b/Filter/Extension/Type/NumberRangeFilterType.php
@@ -33,8 +33,8 @@ class NumberRangeFilterType extends AbstractType implements FilterTypeInterface
     public function getDefaultOptions(array $options)
     {
         return array(
-            'left_number' => array(),
-            'right_number' => array(),
+            'left_number' => array('condition_operator' => NumberFilterType::OPERATOR_GREATER_THAN_EQUAL),
+            'right_number' => array('condition_operator' => NumberFilterType::OPERATOR_LOWER_THAN_EQUAL),
         );
     }
 

--- a/Tests/Filter/QueryBuilderTest.php
+++ b/Tests/Filter/QueryBuilderTest.php
@@ -129,6 +129,22 @@ class QueryBuilderTest extends TestCase
         $this->assertEquals($expectedDql, $doctrineQueryBuilder->getDql());
     }
 
+    public function testNumberRangeDefaultValues()
+    {
+        // use filter type options
+        $form = $this->formFactory->create(new RangeFilterType());
+        $filterQueryBuilder = $this->initQueryBuilder();
+
+        $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
+        $request = $this->createRequest(array('default_position' => array('left_number' => 1, 'right_number' => 3)));
+        $form->bindRequest($request);
+
+        $expectedDql = 'SELECT i FROM Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Entity i WHERE (i.default_position >= :left_default_position_param AND i.default_position <= :right_default_position_param)';
+        $filterQueryBuilder->buildQuery($form, $doctrineQueryBuilder);
+
+        $this->assertEquals($expectedDql, $doctrineQueryBuilder->getDql());
+    }
+
     public function testDateRange()
     {
         // use filter type options

--- a/Tests/Fixtures/Filter/RangeFilterType.php
+++ b/Tests/Fixtures/Filter/RangeFilterType.php
@@ -21,6 +21,7 @@ class RangeFilterType extends AbstractType
                     'left_number' => array('condition_operator' => NumberFilterType::OPERATOR_GREATER_THAN),
                     'right_number' => array('condition_operator' => NumberFilterType::OPERATOR_LOWER_THAN)
                 ))
+                ->add('default_position', 'filter_number_range')
                 ->add('createdAt', 'filter_date_range', array(
                     'left_date' => array('widget' => 'choice'),
                     'right_date' => array('widget' => 'choice')


### PR DESCRIPTION
I think biggest use-case for number range filter is when you want equal to/greater than on left side and smaller than/equal to right side. 

So it would be reasonable to provide users an out of the box option to use it like this.
