### PR TITLE
fixed deprecated reference pass usage

### DIFF
--- a/Filter/QueryBuilderUpdater.php
+++ b/Filter/QueryBuilderUpdater.php
@@ -84,7 +84,7 @@ class QueryBuilderUpdater implements QueryBuilderUpdaterInterface
                 $join = $alias.'.'.$child->getName();
 
                 if (!isset($this->parts[$join])) {
-                    $qbe = new QueryBuilderExecuter($queryBuilder, $alias, $this->expr, & $this->parts);
+                    $qbe = new QueryBuilderExecuter($queryBuilder, $alias, $this->expr, $this->parts);
                     $type->addShared($qbe);
                 }
 


### PR DESCRIPTION
PHP was throwing deprecated errrors on this to me. In short you don't specify reference calls this way anymore, you only need to specify it in method header.

More info at http://stackoverflow.com/questions/4665782/call-time-pass-by-reference-has-been-deprecated

P.S. In fact this is the reason your Travis CI is all red :) http://travis-ci.org/#!/lexik/LexikFormFilterBundle
