### PR TITLE
fix for a weird '<value> is not defined' bug

### DIFF
--- a/Filter/Extension/Type/ChoiceFilterType.php
+++ b/Filter/Extension/Type/ChoiceFilterType.php
@@ -46,7 +46,8 @@ class ChoiceFilterType extends ChoiceType implements FilterTypeInterface
     public function applyFilter(QueryBuilder $queryBuilder, Expr $expr, $field, array $values)
     {
         if (!empty($values['value'])) {
-            $queryBuilder->andWhere($expr->eq($field, $values['value']));
+            $queryBuilder->andWhere($expr->eq($field, ':value'))
+                         ->setParameter('value', $values['value']);
         }
     }
 }


### PR DESCRIPTION
I'm not sure if it's me misconfiguring something or doctrine acting weird but after upgrading to symfony 2.1 (and doctrine 2.2) I kept getting an error like this `[Semantical Error] line 0, col 196 near '<value_here>': Error: '<value_here>' is not defined.` 

This seems to only happen for filter_choice fields :/
