### PR TITLE
fixed broken entity filter for multiple entities choice

### DIFF
--- a/Filter/Extension/Type/EntityFilterType.php
+++ b/Filter/Extension/Type/EntityFilterType.php
@@ -56,11 +56,7 @@ class EntityFilterType extends AbstractFilterType implements FilterTypeInterface
                 }
 
                 if (count($ids) > 0) {
-                    $alias = $value['alias'];
-                    $joinAlias = 'a' . $alias;
-                    $queryBuilder
-                        ->leftJoin($field, $joinAlias)
-                        ->andWhere($expr->in($joinAlias, $ids));
+                    $queryBuilder->andWhere($expr->in($field, $ids));
                 }
 
             } else {


### PR DESCRIPTION
Not sure how it was supposed to work, but it's broken as is for entity filter field with multiple choices option.

The code part doesn't even make sense as at [few lines above](https://github.com/lexik/LexikFormFilterBundle/blob/master/Filter/Extension/Type/EntityFilterType.php#L52) it's established that `$value` in this context is supposed to be an entity, then it's suddenly [an array](https://github.com/lexik/LexikFormFilterBundle/blob/master/Filter/Extension/Type/EntityFilterType.php#L59)
