### PR TITLE
Fix a problem with multiple choice fields in a query

### DIFF
--- a/Filter/Extension/Type/ChoiceFilterType.php
+++ b/Filter/Extension/Type/ChoiceFilterType.php
@@ -44,8 +44,11 @@ class ChoiceFilterType extends AbstractFilterType implements FilterTypeInterface
     public function applyFilter(QueryBuilder $queryBuilder, Expr $expr, $field, array $values)
     {
         if (!empty($values['value'])) {
-            $queryBuilder->andWhere($expr->eq($field, ':value'))
-                         ->setParameter('value', $values['value']);
+            // alias.field -> alias_field
+            $fieldName = str_replace('.', '_', $field);
+
+            $queryBuilder->andWhere($expr->eq($field, ':' . $fieldName))
+                         ->setParameter($fieldName, $values['value']);
         }
     }
 }


### PR DESCRIPTION
This problem occurs where you have 2 or more choice fields in a form, all bound parameters will be overwritten by last since it's name is hardcoded as `value`

NB! Might need to check all other filters for similar problem
