### PR TITLE
added support for no lower/upper limits on number range filter

### DIFF
--- a/Filter/Extension/Type/NumberRangeFilterType.php
+++ b/Filter/Extension/Type/NumberRangeFilterType.php
@@ -68,12 +68,19 @@ class NumberRangeFilterType extends AbstractFilterType implements FilterTypeInte
     public function applyFilter(QueryBuilder $queryBuilder, Expr $expr, $field, array $values)
     {
         $value = $values['value'];
-        if (isset($value['left_number'][0], $value['right_number'][0])) {
+
+        if (isset($value['left_number'][0])) {
             $leftCond   = $value['left_number']['condition_operator'];
             $leftValue  = $value['left_number'][0];
+            
+            $queryBuilder->andWhere($expr->$leftCond($field, $leftValue));
+        }
+
+        if (isset($value['right_number'][0])) {
             $rightCond  = $value['right_number']['condition_operator'];
             $rightValue = $value['right_number'][0];
-            $queryBuilder->andWhere($expr->andX($expr->$leftCond($field, $leftValue), $expr->$rightCond($field, $rightValue)));
+
+            $queryBuilder->andWhere($expr->$rightCond($field, $rightValue));
         }
     }
 }

--- a/Tests/Filter/QueryBuilderUpdaterTest.php
+++ b/Tests/Filter/QueryBuilderUpdaterTest.php
@@ -138,6 +138,36 @@ class QueryBuilderUpdaterTest extends TestCase
         $this->assertEquals($expectedDql, $doctrineQueryBuilder->getDql());
     }
 
+    public function testNumberRangeNoLowerLimit()
+    {
+        // use filter type options
+        $form = $this->formFactory->create(new RangeFilterType());
+        $filterQueryBuilder = $this->initQueryBuilder();
+
+        $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
+        $form->bind(array('default_position' => array('right_number' => 3)));
+
+        $expectedDql = 'SELECT i FROM Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Entity i WHERE i.default_position <= 3';
+        $filterQueryBuilder->addFilterConditions($form, $doctrineQueryBuilder);
+
+        $this->assertEquals($expectedDql, $doctrineQueryBuilder->getDql());
+    }
+
+    public function testNumberRangeNoUpperLimit()
+    {
+        // use filter type options
+        $form = $this->formFactory->create(new RangeFilterType());
+        $filterQueryBuilder = $this->initQueryBuilder();
+
+        $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
+        $form->bind(array('default_position' => array('left_number' => 1)));
+
+        $expectedDql = 'SELECT i FROM Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Entity i WHERE i.default_position >= 1';
+        $filterQueryBuilder->addFilterConditions($form, $doctrineQueryBuilder);
+
+        $this->assertEquals($expectedDql, $doctrineQueryBuilder->getDql());
+    }
+
     public function testDateRange()
     {
         // use filter type options


### PR DESCRIPTION
One common use case for number range filter is where you let a user filter out items by quantities.
In this case it's very common that a user would want to skip lower/upper limits, i.e.  "I want to see all items with quantity above 10". 

Currently only way to achieve this is to specify `0` for lower or `999999999999` for upper.
PR fixes this :)
