### PR TITLE
Update Filter/Extension/Type/DateRangeFilterType.php

### DIFF
--- a/Filter/Extension/Type/DateRangeFilterType.php
+++ b/Filter/Extension/Type/DateRangeFilterType.php
@@ -61,7 +61,8 @@ class DateRangeFilterType extends AbstractFilterType implements FilterTypeInterf
     public function applyFilter(QueryBuilder $queryBuilder, Expr $expr, $field, array $values)
     {
         $value = $values['value'];
-        if(isset($value['left_date'][0]) || $value['right_date'][0])
+        if(isset($value['left_date'][0]) || $value['right_date'][0]){
             $queryBuilder->andWhere($expr->dateInRange($field, $value['left_date'][0], $value['right_date'][0]));
+        }
     }
 }


### PR DESCRIPTION
Hi, 

we were using a DateRangeFilter and we found an error.  When you we do a filter without date values, the applyFilter method builds a query with an empty WHERE clause, causing an exception.
