### PR TITLE
Parameter transformer_id in Types moved to form option.

### DIFF
--- a/Filter/Extension/Type/BooleanFilterType.php
+++ b/Filter/Extension/Type/BooleanFilterType.php
@@ -20,7 +20,7 @@ class BooleanFilterType extends AbstractFilterType implements FilterTypeInterfac
 {
     const VALUE_YES = 'y';
     const VALUE_NO  = 'n';
-
+    
     /**
      * @var \Symfony\Component\Translation\TranslatorInterface
      */
@@ -49,13 +49,19 @@ class BooleanFilterType extends AbstractFilterType implements FilterTypeInterfac
     {
         parent::setDefaultOptions($resolver);
 
-        $resolver->setDefaults(array(
-            'choices'     => array(
-                self::VALUE_YES  => $this->trans('boolean.yes'),
-                self::VALUE_NO   => $this->trans('boolean.no'),
-            ),
-            'empty_value' => $this->trans('boolean.yes_or_no'),
-        ));
+        $resolver
+            ->setDefaults(array(
+                'choices'     => array(
+                    self::VALUE_YES  => $this->trans('boolean.yes'),
+                    self::VALUE_NO   => $this->trans('boolean.no'),
+                ),
+                'empty_value' => $this->trans('boolean.yes_or_no'),
+                'transformer_id' => 'lexik_form_filter.transformer.default',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.default'),
+            ))                
+            ;
     }
 
     /**
@@ -82,14 +88,6 @@ class BooleanFilterType extends AbstractFilterType implements FilterTypeInterfac
         return ($this->translator instanceof TranslatorInterface)
             ? $this->translator->trans($key, $parameters, $domain)
             : $key;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.default';
     }
 
     /**

--- a/Filter/Extension/Type/CheckboxFilterType.php
+++ b/Filter/Extension/Type/CheckboxFilterType.php
@@ -17,6 +17,23 @@ class CheckboxFilterType extends AbstractFilterType implements FilterTypeInterfa
     /**
      * {@inheritdoc}
      */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+        
+        $resolver
+            ->setDefaults(array(
+                'transformer_id' => 'lexik_form_filter.transformer.default',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.default'),
+            ))
+        ;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return 'checkbox';
@@ -28,14 +45,6 @@ class CheckboxFilterType extends AbstractFilterType implements FilterTypeInterfa
     public function getName()
     {
         return 'filter_checkbox';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.default';
     }
 
     /**

--- a/Filter/Extension/Type/ChoiceFilterType.php
+++ b/Filter/Extension/Type/ChoiceFilterType.php
@@ -17,6 +17,23 @@ class ChoiceFilterType extends AbstractFilterType implements FilterTypeInterface
     /**
      * {@inheritdoc}
      */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver
+            ->setDefaults(array(
+                'transformer_id' => 'lexik_form_filter.transformer.default',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.default'),
+            ))                
+            ;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return 'choice';
@@ -28,14 +45,6 @@ class ChoiceFilterType extends AbstractFilterType implements FilterTypeInterface
     public function getName()
     {
         return 'filter_choice';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.default';
     }
 
     /**

--- a/Filter/Extension/Type/DateFilterType.php
+++ b/Filter/Extension/Type/DateFilterType.php
@@ -12,6 +12,23 @@ class DateFilterType extends AbstractFilterType implements FilterTypeInterface
     /**
      * {@inheritdoc}
      */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver
+            ->setDefaults(array(
+                'transformer_id' => 'lexik_form_filter.transformer.default',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.default'),
+            ))                
+            ;
+    }
+    
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return 'date';
@@ -23,14 +40,6 @@ class DateFilterType extends AbstractFilterType implements FilterTypeInterface
     public function getName()
     {
         return 'filter_date';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.default';
     }
 
     /**

--- a/Filter/Extension/Type/DateRangeFilterType.php
+++ b/Filter/Extension/Type/DateRangeFilterType.php
@@ -33,10 +33,16 @@ class DateRangeFilterType extends AbstractFilterType implements FilterTypeInterf
     {
         parent::setDefaultOptions($resolver);
 
-        $resolver->setDefaults(array(
-            'left_date'  => array(),
-            'right_date' => array(),
-        ));
+        $resolver
+            ->setDefaults(array(
+                'left_date'  => array(),
+                'right_date' => array(),
+                'transformer_id' => 'lexik_form_filter.transformer.value_keys',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.value_keys'),
+            ))                                
+            ;
     }
 
     /**
@@ -45,14 +51,6 @@ class DateRangeFilterType extends AbstractFilterType implements FilterTypeInterf
     public function getName()
     {
         return 'filter_date_range';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.value_keys';
     }
 
     /**

--- a/Filter/Extension/Type/EntityFilterType.php
+++ b/Filter/Extension/Type/EntityFilterType.php
@@ -18,6 +18,23 @@ class EntityFilterType extends AbstractFilterType implements FilterTypeInterface
     /**
      * {@inheritdoc}
      */
+    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        parent::setDefaultOptions($resolver);
+
+        $resolver
+            ->setDefaults(array(
+                'transformer_id' => 'lexik_form_filter.transformer.default',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.default'),
+            ))                
+            ;
+    }    
+    
+    /**
+     * {@inheritdoc}
+     */
     public function getParent()
     {
         return 'entity';
@@ -29,14 +46,6 @@ class EntityFilterType extends AbstractFilterType implements FilterTypeInterface
     public function getName()
     {
         return 'filter_entity';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.default';
     }
 
     /**

--- a/Filter/Extension/Type/FilterTypeInterface.php
+++ b/Filter/Extension/Type/FilterTypeInterface.php
@@ -23,10 +23,4 @@ interface FilterTypeInterface
      */
     public function applyFilter(QueryBuilder $queryBuilder, Expr $expr, $field, array $values);
 
-    /**
-     * Return service id used to transforme values
-     *
-     * @return string
-     */
-    public function getTransformerId();
 }

--- a/Filter/Extension/Type/NumberFilterType.php
+++ b/Filter/Extension/Type/NumberFilterType.php
@@ -26,18 +26,11 @@ class NumberFilterType extends AbstractFilterType implements FilterTypeInterface
     const SELECT_OPERATOR = 'select_operator';
 
     /**
-     * @var string
-     */
-    protected $transformerId;
-
-    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         parent::buildForm($builder, $options);
-
-        $this->transformerId = 'lexik_form_filter.transformer.default';
 
         if (true === $options['compound']) {
             // if the form is compound we don't need the NumberToLocalizedStringTransformer added in the parent type.
@@ -46,7 +39,6 @@ class NumberFilterType extends AbstractFilterType implements FilterTypeInterface
             $builder->add('condition_operator', 'choice', $options['choice_options']);
             $builder->add('text', 'number', $options['number_options']);
 
-            $this->transformerId = 'lexik_form_filter.transformer.text';
         } else {
             $builder->setAttribute('filter_options', array(
                 'condition_operator' => $options['condition_operator'],
@@ -64,18 +56,29 @@ class NumberFilterType extends AbstractFilterType implements FilterTypeInterface
         $compound = function (Options $options) {
             return $options['condition_operator'] == NumberFilterType::SELECT_OPERATOR;
         };
+        
+        $transformerId = function (Options $options) {
+            return $options['compound'] ? 'lexik_form_filter.transformer.text' : 'lexik_form_filter.transformer.default';
+        };
 
-        $resolver->setDefaults(array(
-            'condition_operator' => self::OPERATOR_EQUAL,
-            'compound'           => $compound,
-            'number_options'     => array(
-                'required' => false,
-            ),
-            'choice_options'     => array(
-                'choices'  => self::getOperatorChoices(),
-                'required' => false,
-            ),
-        ));
+        $resolver
+            ->setDefaults(array(
+                'condition_operator' => self::OPERATOR_EQUAL,
+                'compound'           => $compound,
+                'number_options'     => array(
+                    'required' => false,
+                ),
+                'choice_options'     => array(
+                    'choices'  => self::getOperatorChoices(),
+                    'required' => false,
+                ),
+                'transformer_id' => $transformerId,
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.text','lexik_form_filter.transformer.default'),
+            ))                  
+            
+            ;
     }
 
     /**
@@ -92,14 +95,6 @@ class NumberFilterType extends AbstractFilterType implements FilterTypeInterface
     public function getName()
     {
         return 'filter_number';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return $this->transformerId;
     }
 
     /**

--- a/Filter/Extension/Type/NumberRangeFilterType.php
+++ b/Filter/Extension/Type/NumberRangeFilterType.php
@@ -40,10 +40,16 @@ class NumberRangeFilterType extends AbstractFilterType implements FilterTypeInte
     {
         parent::setDefaultOptions($resolver);
 
-        $resolver->setDefaults(array(
-            'left_number' => array('condition_operator' => NumberFilterType::OPERATOR_GREATER_THAN_EQUAL),
-            'right_number' => array('condition_operator' => NumberFilterType::OPERATOR_LOWER_THAN_EQUAL),
-        ));
+        $resolver
+            ->setDefaults(array(
+                'left_number' => array('condition_operator' => NumberFilterType::OPERATOR_GREATER_THAN_EQUAL),
+                'right_number' => array('condition_operator' => NumberFilterType::OPERATOR_LOWER_THAN_EQUAL),
+                'transformer_id' => 'lexik_form_filter.transformer.value_keys',
+            ))
+            ->setAllowedValues(array(
+                'transformer_id' => array('lexik_form_filter.transformer.value_keys'),
+            ))                                  
+            ;
     }
 
     /**
@@ -52,14 +58,6 @@ class NumberRangeFilterType extends AbstractFilterType implements FilterTypeInte
     public function getName()
     {
         return 'filter_number_range';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getTransformerId()
-    {
-        return 'lexik_form_filter.transformer.value_keys';
     }
 
     /**

--- a/Filter/QueryBuilderUpdater.php
+++ b/Filter/QueryBuilderUpdater.php
@@ -138,12 +138,12 @@ class QueryBuilderUpdater implements QueryBuilderUpdaterInterface
      */
     protected function prepareFilterValues(FormInterface $form, FilterTypeInterface $type)
     {
-        $values      = array();
-        $transformer = $this->filterTransformerAggregator->get($type->getTransformerId());
-        $values      = $transformer->transform($form);
-
+        $values      = array();        
         $config = $form->getConfig();
-
+        
+        $transformer = $this->filterTransformerAggregator->get($config->getOption('transformer_id'));
+        $values      = $transformer->transform($form);
+        
         if ($config->hasAttribute('filter_options')) {
             $values = array_merge($values, $config->getAttribute('filter_options'));
         }


### PR DESCRIPTION
``` php
<?php

namespace Test\TestBundle\Controller;

use Symfony\Bundle\FrameworkBundle\Controller\Controller;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
use Test\TestBundle\Filter\TestFilterType;
use Lexik\Bundle\FormFilterBundle\Filter\Extension\Type\TextFilterType;


/**
 * @Route("/test")
 */

class DefaultController extends Controller
{
    /**
     * @Route("/")
     * @Template()
     */
    public function indexAction()
    {

        $builder = $this->createFormBuilder();

        $builder->add('foo', 'filter_text', array(
            'condition_pattern' => TextFilterType::SELECT_PATTERN,
        ));

        $builder->add('bar', 'filter_text');

        $filter = $builder->getForm();

        echo 'foo_transformer_id: '.$filter->get('foo')->getConfig()->getType()->getInnerType()->getTransformerId();       
        echo '<br/>';
        echo 'bar_transformer_id: '.$filter->get('bar')->getConfig()->getType()->getInnerType()->getTransformerId();


        die();
    }
}
```

foo_transformer_id should be set to lexik_form_filter.transformer.text but it is set to lexik_form_filter.transformer.default
