### PR TITLE
filter did not use setParameter()

### DIFF
--- a/Filter/ORM/Filters/EntityFilter.php
+++ b/Filter/ORM/Filters/EntityFilter.php
@@ -48,7 +48,8 @@ class EntityFilter extends ORMFilter
                     throw new \Exception(sprintf('Can\'t call method "getId()" on an instance of "%s"', get_class($values['value'])));
                 }
 
-                $filterBuilder->andWhere($expr->eq($field, $values['value']->getId()));
+                $fieldAlias = substr($field, strpos($field, '.') + 1);
+                $filterBuilder->andWhere($expr->eq($field, ':' . $fieldAlias))->setParameter($fieldAlias, $values['value']->getId());
             }
         }
     }


### PR DESCRIPTION
In old code, without using parameters, values used for filtering where not passing by Doctrine escape. So, if you had an Entity with string "id", query failed for invalid SQL (since no escape implies no quotes). Also, no escape is insecure.
