### PR TITLE
docfix

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -6,7 +6,7 @@ Add the bunde to your `composer.json` file:
 ```javascript
 require: {
     // ...
-    "lexik/form-filter-bundle": "v1.2.*"
+    "lexik/form-filter-bundle": "1.2.*"
     // ...
 }
 ```


### PR DESCRIPTION
I modified the version of LxikFormFilterBundle of require section of composer.json in Ressources/doc/index.md
An unnecessary "v" was present and prevented composer.phar to work correctly.
