### PR TITLE
Properly use the alias passed in

### DIFF
--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -87,7 +87,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
             $this->parts[$alias] = '__root__';
         }
 
-        $this->addFilters($form, $event->getFilterQuery(), $event->getFilterQuery()->getAlias(), $this->parts);
+        $this->addFilters($form, $event->getFilterQuery(), $alias, $this->parts);
 
         return $queryBuilder;
     }


### PR DESCRIPTION
When calling addFilterConditions, the third parameter is $alias,
however it is never used as the function addFilters calls
event->getFilterQuery()->getAlias() regardless of the value of $alias.
