### PR TITLE
alias dev-master to 2.x.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,5 +33,10 @@
     "config": {
         "bin-dir": "bin"
     },
-    "target-dir": "Lexik/Bundle/FormFilterBundle"
+    "target-dir": "Lexik/Bundle/FormFilterBundle",
+    "extra": {
+        "branch-aliases": {
+            "dev-master": "2.x.x-dev"
+        }
+    }
 }


### PR DESCRIPTION
Make sure people who want the latest dev-master can get it even if they
set ~2.0 as a requirement. But if you change it to 3.x.x-dev, people won't get BC-breaking updates accidentally.
