### PR TITLE
fix typo in property name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "target-dir": "Lexik/Bundle/FormFilterBundle",
     "extra": {
-        "branch-aliases": {
+        "branch-alias": {
             "dev-master": "2.x.x-dev"
         }
     }


### PR DESCRIPTION
I made a mistake, it's singular, not plural actually... sorry for that.
