### PR TITLE
Fix namespace for the closure Expr argument

### DIFF
--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -439,9 +439,9 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\ORM\Query\Expr;
 
 use Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderExecuterInterface;
-use Lexik\Bundle\FormFilterBundle\Filter\Expr;
 use Lexik\Bundle\FormFilterBundle\Filter\Extension\Type\FilterTypeSharedableInterface;
 
 /**


### PR DESCRIPTION
If we follow the documentation, we get an error message like the following :

> [...]must be an instance of Lexik\Bundle\FormFilterBundle\Filter\ORM\Expr, instance of Doctrine\ORM\Query\Expr given[...]