### PR TITLE
Removes deprecated

### DIFF
--- a/Filter/ORM/Expr.php
+++ b/Filter/ORM/Expr.php
@@ -6,9 +6,6 @@ use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 
 use Doctrine\ORM\Query\Expr\Orx;
 
-/**
- * @deprecated Deprecated since version 2.0, to be removed in 2.1. Use ExpressionBuilder class on Doctrine namespace.
- */
 class Expr extends \Doctrine\ORM\Query\Expr
 {
     const SQL_DATE      = 'Y-m-d';


### PR DESCRIPTION
It's actually not deprecated.
In \Doctrine\ORM\Query\Expr, it's in todo list :
> @todo Rename: ExpressionBuilder