### PR TITLE
Fix invalid SQL with boolean filters

### DIFF
--- a/Event/Subscriber/DoctrineSubscriber.php
+++ b/Event/Subscriber/DoctrineSubscriber.php
@@ -122,8 +122,8 @@ class DoctrineSubscriber implements EventSubscriberInterface
         $values = $event->getValues();
 
         if (!empty($values['value'])) {
-            $value = (int)(BooleanFilterType::VALUE_YES == $values['value']);
-            $qb->andWhere($expr->eq($event->getField(), $value));
+            $value = (bool)(BooleanFilterType::VALUE_YES == $values['value']);
+            $qb->andWhere($expr->eq($event->getField(), $qb->expr()->literal($value)));
         }
     }
 


### PR DESCRIPTION
Boolean filters are treated as integer (example `SELECT ... WHERE boolean_field_name = [0|1]`). This behaviors is tolerated by Mysql but is not valid SQL and so does not work with some others DBMS like PostgreSQL.
