### PR TITLE
Fix ValueKeysExtractionMethod so handleRequest can get used properly

### DIFF
--- a/Filter/DataExtractor/Method/ValueKeysExtractionMethod.php
+++ b/Filter/DataExtractor/Method/ValueKeysExtractionMethod.php
@@ -25,7 +25,7 @@ class ValueKeysExtractionMethod implements DataExtractionMethodInterface
      */
     public function extract(FormInterface $form)
     {
-        $data   = $form->getData();
+        $data   = $form->getData() ?: array();
         $keys   = array();
         $config = $form->getConfig();
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Documentation
 
 The `master` branch is compatible with Symfony 2.3 or higher, if you are using Symfony 2.0.x use the `symfony2.0` branch.
 
-For installation and how to use the bundle refer to [Resources/doc/index.md](https://github.com/lexik/LexikFormFilterBundle/blob/master/Resources/doc/index.md)
+For installation and how to use the bundle refer to [Resources/doc/index.md](Resources/doc/index.md)
 
 Running the test suite
 ======================

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -9,4 +9,5 @@
     5. [Working with entity associations and embeddeding filters](working-with-the-bundle.md#v-working-with-entity-associations-and-embeddeding-filters)
     6. [Doctrine embeddables](working-with-the-bundle.md#vi-doctrine-embeddables)
     7. [Create your own filter type](working-with-the-bundle.md#vii-create-your-own-filter-type)
+    8. [Enable validation on your filter type](working-with-the-bundle.md#viii-enable-filtertype-form-validation)
 5. [The FilterTypeExtension](filtertypeextension.md)

--- a/Resources/doc/working-with-the-bundle.md
+++ b/Resources/doc/working-with-the-bundle.md
@@ -724,6 +724,38 @@ class FilterSubscriber implements EventSubscriberInterface
 }
 ```
 
+viii. Enable FilterType form validation
+---------------------------------------
+
+By default most `FilterForms` are submitted using `GET`, and are defined in class instead of via a formBuilder in the controller. When you injected the data in the `FilterForm` yourself via the `$form->submit($data)` method, all was fine. In order to let the `validator` service function properly, we need to tell the form it does use the `GET` method:
+
+```php
+ public function setDefaultOptions(OptionsResolverInterface $resolver)
+{
+	parent::setDefaultOptions($resolver);
+    $resolver->setDefaults(array(
+        'error_bubbling' 	=> true,
+		'csrf_protection'   => false,
+		'validation_groups' => array('filtering'), // avoid NotBlank() constraint-related message
+        'method'            => 'get',
+    ));
+}
+```
+
+In order to automatically validate your requests, you have to make use of Symfony its built-in `$form->handleRequest()` function. In your controller, you can create your forms in a different way:
+
+```php
+// Handle the filtering
+$filterForm = $this->createForm(new OrderFilterType());
+
+$filterForm->handleRequest($request);
+
+if ($filterForm->isValid()) {
+	$filterBuilder = $this->get('lexik_form_filter.query_builder_updater')->addFilterConditions($filterForm, $filterBuilder);
+}
+```
+Now the Symfony `requestHandler` will take over and won't `addFilterConditions` to the builder in case the form isn't valid.
+
 ***
 
 Next: [5. The FilterTypeExtension](filtertypeextension.md)


### PR DESCRIPTION
The `ValueKeysExtractionMethod` did not work when the form data was emtpy, resulting in an error when you're using `$form->handleRequest()` for `filter_*_range` types.

Also added documentation about how to enable the Symfony validation for the forms.

Fixes #139 