### PR TITLE
Don't call array_merge with null data

### DIFF
--- a/Filter/DataExtractor/Method/ValueKeysExtractionMethod.php
+++ b/Filter/DataExtractor/Method/ValueKeysExtractionMethod.php
@@ -29,7 +29,7 @@ class ValueKeysExtractionMethod implements DataExtractionMethodInterface
         $keys   = array();
         $config = $form->getConfig();
 
-        if ($config->hasAttribute('filter_value_keys')) {
+        if ($config->hasAttribute('filter_value_keys') && is_array($data)) {
             $keys = array_merge($data, $config->getAttribute('filter_value_keys'));
         }
 


### PR DESCRIPTION
This code was causing a PHP warning when using a `filter_date_range` type with no data bound to the form.

> Warning: array_merge() [<a href='function.array-merge'>function.array-merge</a>]: Argument #1 is not an array in /Users/bkosborne/Sites/ADM/vendor/lexik/form-filter-bundle/Lexik/Bundle/FormFilterBundle/Filter/DataExtractor/Method/ValueKeysExtractionMethod.php line 33

Before doing the `array_merge`, a check is needed to make sure that the form data is also an array (and not null data).

This was mentioned years ago in [this PR](https://github.com/lexik/LexikFormFilterBundle/pull/9) but never merged because the PR had other commits in it that were unrelated.