### PR TITLE
Use mb_strtolower instead strtolower

### DIFF
--- a/Filter/Doctrine/Expression/ExpressionBuilder.php
+++ b/Filter/Doctrine/Expression/ExpressionBuilder.php
@@ -221,7 +221,7 @@ abstract class ExpressionBuilder
     protected function convertTypeToMask($value, $type)
     {
         if ($this->forceCaseInsensitivity) {
-            $value = strtolower($value);
+            $value = mb_strtolower($value);
         }
 
         switch ($type) {


### PR DESCRIPTION
Fix case insensitivity for cyrillic (and other) values and prevent sql error: invalid byte sequence for encoding "UTF8".