### PR TITLE
Handle timezones in a correct way.

### DIFF
--- a/Filter/Doctrine/Expression/ExpressionBuilder.php
+++ b/Filter/Doctrine/Expression/ExpressionBuilder.php
@@ -185,9 +185,7 @@ abstract class ExpressionBuilder
         }
 
         if ($isMax) {
-            $date->setTime(23, 59, 59);
-        } else {
-            $date->setTime(0, 0, 0);
+            $date->modify('+1 day -1 second');
         }
 
         return $this->expr()->literal($date->format(self::SQL_DATE_TIME));

--- a/Tests/Filter/Doctrine/DoctrineQueryBuilderUpdater.php
+++ b/Tests/Filter/Doctrine/DoctrineQueryBuilderUpdater.php
@@ -232,6 +232,24 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals($dqls[0], $doctrineQueryBuilder->{$method}());
     }
 
+    protected function createDateRangeWithTimezoneTest($method, array $dqls)
+    {
+        // use filter type options
+        $form = $this->formFactory->create(new RangeFilterType());
+        $filterQueryBuilder = $this->initQueryBuilder();
+
+        $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
+        $form->submit(array(
+            'startAt' => array(
+                'left_date'  => '2015-10-20',
+                'right_date' => '2015-10-20',
+            ),
+        ));
+
+        $filterQueryBuilder->addFilterConditions($form, $doctrineQueryBuilder);
+        $this->assertEquals($dqls[0], $doctrineQueryBuilder->{$method}());
+    }
+
     public function createDateTimeRangeTest($method, array $dqls)
     {
         // use filter type options

--- a/Tests/Filter/Doctrine/ORMQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/ORMQueryBuilderUpdaterTest.php
@@ -67,6 +67,13 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
         ));
     }
 
+    public function testDateRangeWithTimezone()
+    {
+        parent::createDateRangeWithTimezoneTest('getDQL', array(
+            'SELECT i FROM Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Entity\Item i WHERE i.startAt <= \'2015-10-20 18:59:59\' AND i.startAt >= \'2015-10-19 19:00:00\'',
+        ));
+    }
+
     public function testDateTimeRange()
     {
         parent::createDateTimeRangeTest('getDQL', array(

--- a/Tests/Fixtures/Filter/RangeFilterType.php
+++ b/Tests/Fixtures/Filter/RangeFilterType.php
@@ -33,6 +33,18 @@ class RangeFilterType extends AbstractType
                 'left_datetime_options'  => array('date_widget' => 'single_text', 'time_widget' => 'single_text'),
                 'right_datetime_options' => array(),
             ))
+            ->add('startAt', 'filter_date_range', array(
+                'left_date_options' => array(
+                    'widget' => 'single_text',
+                    'model_timezone' => 'UTC',
+                    'view_timezone' => 'Asia/Karachi'
+                ),
+                'right_date_options' => array(
+                    'widget' => 'single_text',
+                    'model_timezone' => 'UTC',
+                    'view_timezone' => 'Asia/Karachi'
+                ),
+            ))
         ;
     }
 


### PR DESCRIPTION
Hi guys.
It looks like you omitted Symfony2 form options like 'model_timezone' and 'view_timezone' using the next chunk of code:

```php
    protected function convertToSqlDate($date, $isMax = false)
    {
        if (! $date instanceof \DateTime) {
            return;
        }

        if ($isMax) {
            $date->setTime(23, 59, 59);
        } else {
            $date->setTime(0, 0, 0);
        }

        return $this->expr()->literal($date->format(self::SQL_DATE_TIME));
    }
```

We kindly ask you to replace it with something like this one:

```php
    protected function convertToSqlDate($date, $isMax = false)
    {
        if (! $date instanceof \DateTime) {
            return;
        }

        if ($isMax) {
            $date->modify('+1 day -1 second');
        }

        return $this->expr()->literal($date->format(self::SQL_DATE_TIME));
    }
```

It should handle timezones in a correct way.
