### PR TITLE
Compatibility with Symfony 2.8/3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ vendor
 composer.phar
 composer.lock
 bin
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
     - 5.5
     - 5.6
     - 7.0
@@ -17,7 +15,8 @@ services:
     - mongodb
 
 env:
-    - SYMFONY_VERSION=2.7.*
+    - SYMFONY_VERSION=2.8.*
+    - SYMFONY_VERSION=3.0.*
 
 before_script:
     - phpenv config-add travis-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ services:
 
 env:
     - SYMFONY_VERSION=2.8.*
-    - SYMFONY_VERSION=3.0.*
 
 before_script:
     - phpenv config-add travis-php.ini

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ services:
 
 env:
     - SYMFONY_VERSION=2.8.*
+    - SYMFONY_VERSION=3.0.*
 
 before_script:
     - phpenv config-add travis-php.ini

--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -203,7 +203,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
             // trigger a specific or a global event name
             $eventName = sprintf('lexik_form_filter.apply.%s.%s', $filterQuery->getEventPartName(), $completeName);
             if (!$this->dispatcher->hasListeners($eventName)) {
-                $eventName = sprintf('lexik_form_filter.apply.%s.%s', $filterQuery->getEventPartName(), is_string($callable) ? $callable : $formType->getName());
+                $eventName = sprintf('lexik_form_filter.apply.%s.%s', $filterQuery->getEventPartName(), is_string($callable) ? $callable : $formType->getBlockPrefix());
             }
 
             $event = new GetFilterConditionEvent($filterQuery, $field, $values);

--- a/Filter/FilterOperands.php
+++ b/Filter/FilterOperands.php
@@ -88,7 +88,7 @@ final class FilterOperands
             }
         }
 
-        return $choices;
+        return array_flip($choices);
     }
 
     /**
@@ -107,6 +107,6 @@ final class FilterOperands
             }
         }
 
-        return $choices;
+        return array_flip($choices);
     }
 }

--- a/Filter/Form/FilterTypeExtension.php
+++ b/Filter/Form/FilterTypeExtension.php
@@ -7,7 +7,6 @@ use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
 
-
 /**
  * Define filtering options.
  *

--- a/Filter/Form/FilterTypeExtension.php
+++ b/Filter/Form/FilterTypeExtension.php
@@ -3,8 +3,10 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form;
 
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractTypeExtension;
+
 
 /**
  * Define filtering options.
@@ -44,6 +46,6 @@ class FilterTypeExtension extends AbstractTypeExtension
      */
     public function getExtendedType()
     {
-        return 'form';
+        return FormType::class;
     }
 }

--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -19,6 +19,22 @@ class BooleanFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_boolean';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
@@ -34,21 +50,5 @@ class BooleanFilterType extends AbstractType
             ))
             ->setAllowedValues('data_extraction_method', array('default'))
         ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParent()
-    {
-        return ChoiceType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getBlockPrefix()
-    {
-        return 'filter_boolean';
     }
 }

--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -41,9 +41,10 @@ class BooleanFilterType extends AbstractType
             ->setDefaults(array(
                 'required'               => false,
                 'choices'                => array(
-                    self::VALUE_YES  => 'boolean.yes',
-                    self::VALUE_NO   => 'boolean.no',
+                    'boolean.yes' => self::VALUE_YES,
+                    'boolean.no'  => self::VALUE_NO,
                 ),
+                'choices_as_values'      => true, // must be removed for use in Symfony 3.1, needed for 2.8
                 'empty_value'            => 'boolean.yes_or_no',
                 'translation_domain'     => 'LexikFormFilterBundle',
                 'data_extraction_method' => 'default',

--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -19,14 +19,6 @@ class BooleanFilterType extends AbstractType
     /**
      * {@inheritdoc}
      */
-    public function getParent()
-    {
-        return ChoiceType::class;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver
@@ -42,5 +34,21 @@ class BooleanFilterType extends AbstractType
             ))
             ->setAllowedValues('data_extraction_method', array('default'))
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return ChoiceType::class;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_boolean';
     }
 }

--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -20,15 +21,7 @@ class BooleanFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_boolean';
+        return ChoiceType::class;
     }
 
     /**

--- a/Filter/Form/Type/CheckboxFilterType.php
+++ b/Filter/Form/Type/CheckboxFilterType.php
@@ -34,4 +34,12 @@ class CheckboxFilterType extends AbstractType
     {
         return CheckboxType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_checkbox';
+    }
 }

--- a/Filter/Form/Type/CheckboxFilterType.php
+++ b/Filter/Form/Type/CheckboxFilterType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,14 +32,6 @@ class CheckboxFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'checkbox';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_checkbox';
+        return CheckboxType::class;
     }
 }

--- a/Filter/Form/Type/ChoiceFilterType.php
+++ b/Filter/Form/Type/ChoiceFilterType.php
@@ -34,4 +34,12 @@ class ChoiceFilterType extends AbstractType
     {
         return ChoiceType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_choice';
+    }
 }

--- a/Filter/Form/Type/ChoiceFilterType.php
+++ b/Filter/Form/Type/ChoiceFilterType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,14 +32,6 @@ class ChoiceFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'choice';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_choice';
+        return ChoiceType::class;
     }
 }

--- a/Filter/Form/Type/CollectionAdapterFilterType.php
+++ b/Filter/Form/Type/CollectionAdapterFilterType.php
@@ -69,6 +69,6 @@ class CollectionAdapterFilterType extends AbstractType
      */
     public function getParent()
     {
-        return SharedableFilterType();
+        return SharedableFilterType::class;
     }
 }

--- a/Filter/Form/Type/CollectionAdapterFilterType.php
+++ b/Filter/Form/Type/CollectionAdapterFilterType.php
@@ -44,9 +44,9 @@ class CollectionAdapterFilterType extends AbstractType
             $index = 0;
             $childOptions = array_replace(array(
                 'property_path' => sprintf('[%d]', $index),
-            ), $options['options']);
+            ), $options['entry_options']);
 
-            $form->add($index, $options['type'], $childOptions);
+            $form->add($index, $options['entry_type'], $childOptions);
         });
     }
 
@@ -56,12 +56,12 @@ class CollectionAdapterFilterType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
-            'type'         => null,
-            'options'      => array(),
-            'default_data' => array(),
+            'entry_type'    => null,
+            'entry_options' => array(),
+            'default_data'  => array(),
         ));
 
-        $resolver->setRequired(array('type'));
+        $resolver->setRequired(array('entry_type'));
     }
 
     /**
@@ -69,14 +69,6 @@ class CollectionAdapterFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'filter_sharedable';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_collection_adapter';
+        return SharedableFilterType();
     }
 }

--- a/Filter/Form/Type/CollectionAdapterFilterType.php
+++ b/Filter/Form/Type/CollectionAdapterFilterType.php
@@ -71,4 +71,12 @@ class CollectionAdapterFilterType extends AbstractType
     {
         return SharedableFilterType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_collection_adapter';
+    }
 }

--- a/Filter/Form/Type/DateFilterType.php
+++ b/Filter/Form/Type/DateFilterType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,14 +32,6 @@ class DateFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'date';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_date';
+        return DateType::class;
     }
 }

--- a/Filter/Form/Type/DateFilterType.php
+++ b/Filter/Form/Type/DateFilterType.php
@@ -34,4 +34,12 @@ class DateFilterType extends AbstractType
     {
         return DateType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_date';
+    }
 }

--- a/Filter/Form/Type/DateRangeFilterType.php
+++ b/Filter/Form/Type/DateRangeFilterType.php
@@ -18,8 +18,8 @@ class DateRangeFilterType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('left_date', 'filter_date', $options['left_date_options']);
-        $builder->add('right_date', 'filter_date', $options['right_date_options']);
+        $builder->add('left_date', DateFilterType::class, $options['left_date_options']);
+        $builder->add('right_date', DateFilterType::class, $options['right_date_options']);
 
         $builder->setAttribute('filter_value_keys', array(
             'left_date'  => $options['left_date_options'],
@@ -41,13 +41,5 @@ class DateRangeFilterType extends AbstractType
             ))
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_date_range';
     }
 }

--- a/Filter/Form/Type/DateRangeFilterType.php
+++ b/Filter/Form/Type/DateRangeFilterType.php
@@ -42,4 +42,12 @@ class DateRangeFilterType extends AbstractType
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_date_range';
+    }
 }

--- a/Filter/Form/Type/DateTimeFilterType.php
+++ b/Filter/Form/Type/DateTimeFilterType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
@@ -31,14 +32,6 @@ class DateTimeFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'datetime';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_datetime';
+        return DateTimeType::class;
     }
 }

--- a/Filter/Form/Type/DateTimeFilterType.php
+++ b/Filter/Form/Type/DateTimeFilterType.php
@@ -40,6 +40,6 @@ class DateTimeFilterType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'filter_date_time';
+        return 'filter_datetime';
     }
 }

--- a/Filter/Form/Type/DateTimeFilterType.php
+++ b/Filter/Form/Type/DateTimeFilterType.php
@@ -34,4 +34,12 @@ class DateTimeFilterType extends AbstractType
     {
         return DateTimeType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_date_time';
+    }
 }

--- a/Filter/Form/Type/DateTimeRangeFilterType.php
+++ b/Filter/Form/Type/DateTimeRangeFilterType.php
@@ -42,4 +42,12 @@ class DateTimeRangeFilterType extends AbstractType
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_date_time_range';
+    }
 }

--- a/Filter/Form/Type/DateTimeRangeFilterType.php
+++ b/Filter/Form/Type/DateTimeRangeFilterType.php
@@ -48,6 +48,6 @@ class DateTimeRangeFilterType extends AbstractType
      */
     public function getBlockPrefix()
     {
-        return 'filter_date_time_range';
+        return 'filter_datetime_range';
     }
 }

--- a/Filter/Form/Type/DateTimeRangeFilterType.php
+++ b/Filter/Form/Type/DateTimeRangeFilterType.php
@@ -18,8 +18,8 @@ class DateTimeRangeFilterType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('left_datetime', 'filter_datetime', $options['left_datetime_options']);
-        $builder->add('right_datetime', 'filter_datetime', $options['right_datetime_options']);
+        $builder->add('left_datetime', DateTimeFilterType::class, $options['left_datetime_options']);
+        $builder->add('right_datetime', DateTimeFilterType::class, $options['right_datetime_options']);
 
         $builder->setAttribute('filter_value_keys', array(
             'left_datetime'  => $options['left_datetime_options'],
@@ -41,13 +41,5 @@ class DateTimeRangeFilterType extends AbstractType
             ))
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_datetime_range';
     }
 }

--- a/Filter/Form/Type/DocumentFilterType.php
+++ b/Filter/Form/Type/DocumentFilterType.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
+use Doctrine\Bundle\MongoDBBundle\Form\Type\DocumentType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -50,13 +51,13 @@ class DocumentFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'document';
+        return DocumentType::class;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getBlockPrefix()
     {
         return 'filter_document';
     }

--- a/Filter/Form/Type/EntityFilterType.php
+++ b/Filter/Form/Type/EntityFilterType.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -31,14 +32,6 @@ class EntityFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'entity';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_entity';
+        return EntityType::class;
     }
 }

--- a/Filter/Form/Type/EntityFilterType.php
+++ b/Filter/Form/Type/EntityFilterType.php
@@ -34,4 +34,12 @@ class EntityFilterType extends AbstractType
     {
         return EntityType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_entity';
+    }
 }

--- a/Filter/Form/Type/NumberFilterType.php
+++ b/Filter/Form/Type/NumberFilterType.php
@@ -4,6 +4,8 @@ namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -24,8 +26,8 @@ class NumberFilterType extends AbstractType
             // if the form is compound we don't need the NumberToLocalizedStringTransformer added in the parent type.
             $builder->resetViewTransformers();
 
-            $builder->add('condition_operator', 'choice', $options['choice_options']);
-            $builder->add('text', 'number', $options['number_options']);
+            $builder->add('condition_operator', ChoiceType::class, $options['choice_options']);
+            $builder->add('text', NumberType::class, $options['number_options']);
         } else {
             $builder->setAttribute('filter_options', array(
                 'condition_operator' => $options['condition_operator'],
@@ -67,14 +69,6 @@ class NumberFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'number';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_number';
+        return NumberType::class;
     }
 }

--- a/Filter/Form/Type/NumberFilterType.php
+++ b/Filter/Form/Type/NumberFilterType.php
@@ -52,6 +52,7 @@ class NumberFilterType extends AbstractType
                 ),
                 'choice_options'         => array(
                     'choices'            => FilterOperands::getNumberOperandsChoices(),
+                    'choices_as_values'  => true,
                     'required'           => false,
                     'translation_domain' => 'LexikFormFilterBundle',
                 ),

--- a/Filter/Form/Type/NumberFilterType.php
+++ b/Filter/Form/Type/NumberFilterType.php
@@ -71,4 +71,12 @@ class NumberFilterType extends AbstractType
     {
         return NumberType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_number';
+    }
 }

--- a/Filter/Form/Type/NumberRangeFilterType.php
+++ b/Filter/Form/Type/NumberRangeFilterType.php
@@ -43,4 +43,12 @@ class NumberRangeFilterType extends AbstractType
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_number_range';
+    }
 }

--- a/Filter/Form/Type/NumberRangeFilterType.php
+++ b/Filter/Form/Type/NumberRangeFilterType.php
@@ -19,8 +19,8 @@ class NumberRangeFilterType extends AbstractType
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('left_number', 'filter_number', $options['left_number_options']);
-        $builder->add('right_number', 'filter_number', $options['right_number_options']);
+        $builder->add('left_number', NumberFilterType::class, $options['left_number_options']);
+        $builder->add('right_number', NumberFilterType::class, $options['right_number_options']);
 
         $builder->setAttribute('filter_value_keys', array(
             'left_number'  => $options['left_number_options'],
@@ -42,13 +42,5 @@ class NumberRangeFilterType extends AbstractType
             ))
             ->setAllowedValues('data_extraction_method', array('value_keys'))
         ;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_number_range';
     }
 }

--- a/Filter/Form/Type/SharedableFilterType.php
+++ b/Filter/Form/Type/SharedableFilterType.php
@@ -32,4 +32,12 @@ class SharedableFilterType extends AbstractType
             'add_shared' => function (FilterBuilderExecuterInterface $qbe) {},
         ));
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_sharedable';
+    }
 }

--- a/Filter/Form/Type/SharedableFilterType.php
+++ b/Filter/Form/Type/SharedableFilterType.php
@@ -32,12 +32,4 @@ class SharedableFilterType extends AbstractType
             'add_shared' => function (FilterBuilderExecuterInterface $qbe) {},
         ));
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_sharedable';
-    }
 }

--- a/Filter/Form/Type/TextFilterType.php
+++ b/Filter/Form/Type/TextFilterType.php
@@ -4,6 +4,8 @@ namespace Lexik\Bundle\FormFilterBundle\Filter\Form\Type;
 
 use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\Options;
@@ -21,8 +23,8 @@ class TextFilterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (true === $options['compound']) {
-            $builder->add('condition_pattern', 'choice', $options['choice_options']);
-            $builder->add('text', 'text', $options['text_options']);
+            $builder->add('condition_pattern', ChoiceType::class, $options['choice_options']);
+            $builder->add('text', TextType::class, $options['text_options']);
         } else {
             $builder->setAttribute('filter_options', array(
                 'condition_pattern' => $options['condition_pattern'],
@@ -65,14 +67,6 @@ class TextFilterType extends AbstractType
      */
     public function getParent()
     {
-        return 'text';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
-    {
-        return 'filter_text';
+        return TextType::class;
     }
 }

--- a/Filter/Form/Type/TextFilterType.php
+++ b/Filter/Form/Type/TextFilterType.php
@@ -69,4 +69,12 @@ class TextFilterType extends AbstractType
     {
         return TextType::class;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getBlockPrefix()
+    {
+        return 'filter_text';
+    }
 }

--- a/Filter/Form/Type/TextFilterType.php
+++ b/Filter/Form/Type/TextFilterType.php
@@ -50,6 +50,7 @@ class TextFilterType extends AbstractType
                 ),
                 'choice_options'         => array(
                     'choices'            => FilterOperands::getStringOperandsChoices(),
+                    'choices_as_values'  => true,
                     'required'           => false,
                     'translation_domain' => 'LexikFormFilterBundle',
                 ),

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ Once you created your form type you will be able to update a doctrine query buil
 The idea is:
 
 1. Create a form type extending from `Symfony\Component\Form\AbstractType` as usual.
-2. Add form fields by using provided filter types (e.g. use `filter_text` instead of `text` type) (*).
+2. Add form fields by using provided filter types (e.g. use TextFilterType::class instead of a TextType::class type) (*).
 3. Then call a service to build the query from the form instance and execute your query to get your result :).
 
-(*): In fact you can use any type, but if you want to apply a filter by not using a `filter_xxx` type you will have to create a custom listener class to apply the filter for this type.
+(*): In fact you can use any type, but if you want to apply a filter by not using a XxxFilterType::class type you will have to create a custom listener class to apply the filter for this type.
 
 Documentation
 =============
 
-The `master` branch is compatible with Symfony 2.7 or higher, if you are using Symfony 2.0.x use the `symfony2.0` branch.
+This `Symfony3.0` branch is compatible with Symfony 2.8/3.0 or higher.
 
 For installation and how to use the bundle refer to [Resources/doc/index.md](Resources/doc/index.md)
 

--- a/Resources/config/form.xml
+++ b/Resources/config/form.xml
@@ -12,6 +12,7 @@
         <parameter key="lexik_form_filter.type.filter_checkbox.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CheckboxFilterType</parameter>
         <parameter key="lexik_form_filter.type.filter_boolean.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\BooleanFilterType</parameter>
         <parameter key="lexik_form_filter.type.filter_choice.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\ChoiceFilterType</parameter>
+        <parameter key="lexik_form_filter.type.filter_entity.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\EntityFilterType</parameter>
         <parameter key="lexik_form_filter.type.filter_date.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateFilterType</parameter>
         <parameter key="lexik_form_filter.type.filter_date_range.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateRangeFilterType</parameter>
         <parameter key="lexik_form_filter.type.filter_datetime.class">Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateTimeFilterType</parameter>
@@ -26,56 +27,61 @@
     <services>
         <!-- Filter Types -->
         <service id="lexik_form_filter.type.filter_text" class="%lexik_form_filter.type.filter_text.class%">
-            <tag name="form.type" alias="filter_text" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_number" class="%lexik_form_filter.type.filter_number.class%">
-            <tag name="form.type" alias="filter_number" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_number_range" class="%lexik_form_filter.type.filter_number_range.class%">
-            <tag name="form.type" alias="filter_number_range" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_checkbox" class="%lexik_form_filter.type.filter_checkbox.class%">
-            <tag name="form.type" alias="filter_checkbox" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_boolean" class="%lexik_form_filter.type.filter_boolean.class%">
-            <tag name="form.type" alias="filter_boolean" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_choice" class="%lexik_form_filter.type.filter_choice.class%">
-            <tag name="form.type" alias="filter_choice" />
+            <tag name="form.type" />
+        </service>
+
+        <service id="lexik_form_filter.type.filter_entity" class="%lexik_form_filter.type.filter_entity.class%">
+            <argument type="service" id="doctrine" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_date" class="%lexik_form_filter.type.filter_date.class%">
-            <tag name="form.type" alias="filter_date" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_date_range" class="%lexik_form_filter.type.filter_date_range.class%">
-            <tag name="form.type" alias="filter_date_range" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_datetime" class="%lexik_form_filter.type.filter_datetime.class%">
-            <tag name="form.type" alias="filter_datetime" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_datetime_range" class="%lexik_form_filter.type.filter_datetime_range.class%">
-            <tag name="form.type" alias="filter_datetime_range" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_collection_adapter" class="%lexik_form_filter.type.filter_collection_adapter.class%">
-            <tag name="form.type" alias="filter_collection_adapter" />
+            <tag name="form.type" />
         </service>
 
         <service id="lexik_form_filter.type.filter_sharedable" class="%lexik_form_filter.type.filter_sharedable.class%">
-            <tag name="form.type" alias="filter_sharedable" />
+            <tag name="form.type" />
         </service>
 
         <!-- Type extension -->
         <service id="lexik_form_filter.type_extension.filter_extension" class="%lexik_form_filter.type_extension.filter_extension.class%">
-            <tag name="form.type_extension" alias="form" />
+            <tag name="form.type_extension" extended_type="Symfony\Component\Form\Extension\Core\Type\FormType" />
         </service>
     </services>
 </container>

--- a/Tests/Filter/Doctrine/DoctrineQueryBuilderUpdater.php
+++ b/Tests/Filter/Doctrine/DoctrineQueryBuilderUpdater.php
@@ -61,7 +61,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
 
     protected function createBuildQueryTest($method, array $dqls)
     {
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         // without binding the form
@@ -78,7 +78,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals($dqls[1], $doctrineQueryBuilder->{$method}());
 
         // bind a request to the form - 2 params
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
         $form->submit(array('name' => 'blabla', 'position' => 2));
@@ -88,7 +88,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals(array('p_i_position' => 2), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // bind a request to the form - 3 params
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
         $form->submit(array('name' => 'blabla', 'position' => 2, 'enabled' => BooleanFilterType::VALUE_YES));
@@ -98,7 +98,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals(array('p_i_position' => 2, 'p_i_enabled' => true), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // bind a request to the form - 3 params (use checkbox for enabled field)
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'checkbox' => true,
         ));
 
@@ -110,7 +110,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals(array('p_i_position' => 2, 'p_i_enabled' => 1), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // bind a request to the form - date + pattern selector
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => true,
         ));
 
@@ -126,7 +126,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals(array('p_i_position' => 2, 'p_i_createdAt' => new \DateTime('2013-09-27')), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // bind a request to the form - datetime + pattern selector
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => true,
             'datetime'      => true,
         ));
@@ -148,7 +148,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
 
     protected function createDisabledFieldTest($method, array $dqls)
     {
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => false,
             'disabled_name' => true,
         ));
@@ -163,7 +163,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
 
     protected function createApplyFilterOptionTest($method, array $dqls)
     {
-        $form = $this->formFactory->create(new ItemCallbackFilterType());
+        $form = $this->formFactory->create(ItemCallbackFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -176,7 +176,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     protected function createNumberRangeTest($method, array $dqls)
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -193,7 +193,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     protected function createNumberRangeCompoundTest($method, array $dqls)
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -213,7 +213,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     protected function createNumberRangeDefaultValuesTest($method, array $dqls)
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -230,7 +230,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     protected function createDateRangeTest($method, array $dqls)
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -248,7 +248,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     protected function createDateRangeWithTimezoneTest($method, array $dqls)
     {
         // same dates
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array(
             'startAt' => array(
                 'left_date'  => '2015-10-20',
@@ -263,7 +263,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
         $this->assertEquals($dqls[0], $doctrineQueryBuilder->{$method}());
 
         // different dates
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array(
             'startAt' => array(
                 'left_date'  => '2015-10-01',
@@ -281,7 +281,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
     public function createDateTimeRangeTest($method, array $dqls)
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -304,7 +304,7 @@ abstract class DoctrineQueryBuilderUpdater extends TestCase
 
     public function createFilterStandardTypeTest($method, array $dqls)
     {
-        $form = $this->formFactory->create(new FormType());
+        $form = $this->formFactory->create(FormType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();

--- a/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
@@ -244,7 +244,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testDateTimeRange()
     {
         // use filter type options
-        $form = $this->formFactory->create(classRangeFilterType::class);
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array(
             'updatedAt' => array(
                 'left_datetime' => array(

--- a/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
@@ -244,7 +244,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testDateTimeRange()
     {
         // use filter type options
-        $form = $this->formFactory->create(::classRangeFilterType::class);
+        $form = $this->formFactory->create(classRangeFilterType::class);
         $form->submit(array(
             'updatedAt' => array(
                 'left_datetime' => array(

--- a/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/MongodbQueryBuilderUpdaterTest.php
@@ -56,7 +56,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
             '#db.items.find\(\{ "\$and": \[ \{ "name": new RegExp\("\.\*blabla\$", "i"\) \}, \{ "position": \{ "\$lte": 2 \} \}, \{ "createdAt": new ISODate\("2013-09-27T13:21:00\+[0-9:]+"\) \} \] \}\);#',
         );
 
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         // without binding the form
@@ -73,7 +73,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertEquals($bson[1], $this->toBson($mongoQB->getQuery()));
 
         // bind a request to the form - 2 params
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
 
         $mongoQB = $this->createDoctrineQueryBuilder();
         $form->submit(array('name' => 'blabla', 'position' => 2));
@@ -82,7 +82,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertEquals($bson[2], $this->toBson($mongoQB->getQuery()));
 
         // bind a request to the form - 3 params
-        $form = $this->formFactory->create(new ItemFilterType());
+        $form = $this->formFactory->create(ItemFilterType::class);
 
         $mongoQB = $this->createDoctrineQueryBuilder();
         $form->submit(array('name' => 'blabla', 'position' => 2, 'enabled' => BooleanFilterType::VALUE_YES));
@@ -91,7 +91,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertEquals($bson[3], $this->toBson($mongoQB->getQuery()));
 
         // bind a request to the form - 3 params (use checkbox for enabled field)
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'checkbox' => true,
         ));
 
@@ -102,7 +102,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertEquals($bson[4], $this->toBson($mongoQB->getQuery()));
 
         // bind a request to the form - date + pattern selector
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => true,
         ));
 
@@ -117,7 +117,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $this->assertRegExp($bson[5], $this->toBson($mongoQB->getQuery()));
 
         // bind a request to the form - datetime + pattern selector
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => true,
             'datetime'      => true,
         ));
@@ -138,7 +138,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
 
     public function testDisabledFieldQuery()
     {
-        $form = $this->formFactory->create(new ItemFilterType(), null, array(
+        $form = $this->formFactory->create(ItemFilterType::class, null, array(
             'with_selector' => false,
             'disabled_name' => true,
         ));
@@ -156,7 +156,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
 
     public function testApplyFilterOption()
     {
-        $form = $this->formFactory->create(new ItemCallbackFilterType());
+        $form = $this->formFactory->create(ItemCallbackFilterType::class);
         $form->submit(array('name' => 'blabla', 'position' => 2));
 
         $mongoQB = $this->createDoctrineQueryBuilder();
@@ -172,7 +172,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testNumberRange()
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array('position' => array('left_number' => 1, 'right_number' => 3)));
 
         $mongoQB = $this->createDoctrineQueryBuilder();
@@ -188,7 +188,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testNumberRangeWithSelector()
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array('position_selector' => array(
             'left_number'  => array('text' => 4, 'condition_operator' => FilterOperands::OPERATOR_GREATER_THAN),
             'right_number' => array('text' => 8, 'condition_operator' => FilterOperands::OPERATOR_LOWER_THAN_EQUAL),
@@ -207,7 +207,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testNumberRangeDefaultValues()
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array('default_position' => array('left_number' => 1, 'right_number' => 3)));
 
         $mongoQB = $this->createDoctrineQueryBuilder();
@@ -223,7 +223,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testDateRange()
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(RangeFilterType::class);
         $form->submit(array(
             'createdAt' => array(
                 'left_date'  => '2012-05-12',
@@ -244,7 +244,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testDateTimeRange()
     {
         // use filter type options
-        $form = $this->formFactory->create(new RangeFilterType());
+        $form = $this->formFactory->create(::classRangeFilterType::class);
         $form->submit(array(
             'updatedAt' => array(
                 'left_datetime' => array(
@@ -270,7 +270,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
 
     public function testFilterStandardType()
     {
-        $form = $this->formFactory->create(new FormType());
+        $form = $this->formFactory->create(FormType::class);
         $form->submit(array(
             'name'     => 'hey dude',
             'position' => 99,
@@ -289,7 +289,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
     public function testEmbedFormFilter()
     {
         // doctrine query builder without any joins
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'doctrine_builder' => 'mongo',
         ));
         $form->submit(array('name' => 'dude', 'options' => array(array('label' => 'color', 'rank' => 3))));
@@ -305,7 +305,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         );
 
         // doctrine query builder without any joins and values for embedded field only
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'doctrine_builder' => 'mongo',
         ));
         $form->submit(array('options' => array(array('label' => 'color', 'rank' => 3))));
@@ -321,7 +321,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         );
 
         // pre-fill parts
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'doctrine_builder' => 'mongo',
         ));
         $form->submit(array('name' => 'dude', 'options' => array(array('label' => 'size', 'rank' => 5))));
@@ -343,7 +343,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         // doctrine query builder without any joins + custom condition builder
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'doctrine_builder'         => 'mongo',
             'filter_condition_builder' => function (ConditionBuilderInterface $builder) {
                 $builder
@@ -369,7 +369,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
         );
 
         // doctrine query builder without any joins + custom condition builder
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'doctrine_builder'         => 'mongo',
             'filter_condition_builder' => function (ConditionBuilderInterface $builder) {
                 $builder
@@ -400,7 +400,7 @@ class MongodbQueryBuilderUpdaterTest extends TestCase
 
     public function testWithDataClass()
     {
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'data_class'       => 'Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Document\Item',
             'doctrine_builder' => 'mongo',
         ));

--- a/Tests/Filter/Doctrine/ORMQueryBuilderUpdaterTest.php
+++ b/Tests/Filter/Doctrine/ORMQueryBuilderUpdaterTest.php
@@ -92,7 +92,7 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
     public function testEmbedFormFilter()
     {
         // doctrine query builder without any joins
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType());
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -106,7 +106,7 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
         $this->assertEquals(array('p_opt_rank' => 3), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // doctrine query builder with joins
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType());
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class);
         $filterQueryBuilder = $this->initQueryBuilderUpdater();
 
         $doctrineQueryBuilder = $this->createDoctrineQueryBuilder();
@@ -126,7 +126,7 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
     public function testCustomConditionBuilder()
     {
         // doctrine query builder without any joins + custom condition builder
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'filter_condition_builder' => function (ConditionBuilderInterface $builder) {
                 $builder
                     ->root('or')
@@ -152,7 +152,7 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
         $this->assertEquals(array('p_opt_rank' => 6), $this->getQueryBuilderParameters($doctrineQueryBuilder));
 
         // doctrine query builder without any joins + custom condition builder
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'filter_condition_builder' => function (ConditionBuilderInterface $builder) {
                     $builder
                         ->root('and')
@@ -184,7 +184,7 @@ class ORMQueryBuilderUpdaterTest extends DoctrineQueryBuilderUpdater
     public function testWithDataClass()
     {
         // doctrine query builder without any joins + a data_class
-        $form = $this->formFactory->create(new ItemEmbeddedOptionsFilterType(), null, array(
+        $form = $this->formFactory->create(ItemEmbeddedOptionsFilterType::class, null, array(
             'data_class' => 'Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Entity\Item',
         ));
         $filterQueryBuilder = $this->initQueryBuilderUpdater();

--- a/Tests/Fixtures/Filter/FormType.php
+++ b/Tests/Fixtures/Filter/FormType.php
@@ -34,4 +34,9 @@ class FormType extends AbstractType
             },
         ));
     }
+
+    public function getBlockPrefix()
+    {
+        return 'my_form';
+    }
 }

--- a/Tests/Fixtures/Filter/FormType.php
+++ b/Tests/Fixtures/Filter/FormType.php
@@ -5,6 +5,8 @@ namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\IntegerType;
 
 /**
  * Form filter for tests.
@@ -15,8 +17,8 @@ class FormType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'text');
-        $builder->add('position', 'integer', array(
+        $builder->add('name', TextType::class);
+        $builder->add('position', IntegerType::class, array(
             'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                 if (!empty($values['value'])) {
                     if ($filterQuery->getExpr() instanceof \Doctrine\MongoDB\Query\Expr) {
@@ -31,10 +33,5 @@ class FormType extends AbstractType
                 return null;
             },
         ));
-    }
-
-    public function getName()
-    {
-        return 'my_form';
     }
 }

--- a/Tests/Fixtures/Filter/ItemCallbackFilterType.php
+++ b/Tests/Fixtures/Filter/ItemCallbackFilterType.php
@@ -37,6 +37,11 @@ class ItemCallbackFilterType extends AbstractType
         ));
     }
 
+    public function getBlockPrefix()
+    {
+        return 'item_filter';
+    }
+
     public function fieldNameCallback(QueryInterface $filterQuery, $field, $values)
     {
         if (!empty($values['value'])) {

--- a/Tests/Fixtures/Filter/ItemCallbackFilterType.php
+++ b/Tests/Fixtures/Filter/ItemCallbackFilterType.php
@@ -2,6 +2,8 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -15,10 +17,10 @@ class ItemCallbackFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('name', 'filter_text', array(
+        $builder->add('name', TextFilterType::class, array(
             'apply_filter' => array($this, 'fieldNameCallback'),
         ));
-        $builder->add('position', 'filter_number', array(
+        $builder->add('position', NumberFilterType::class, array(
             'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                 if (!empty($values['value'])) {
                     if ($filterQuery->getExpr() instanceof \Doctrine\MongoDB\Query\Expr) {
@@ -33,11 +35,6 @@ class ItemCallbackFilterType extends AbstractType
                 return null;
             },
         ));
-    }
-
-    public function getName()
-    {
-        return 'item_filter';
     }
 
     public function fieldNameCallback(QueryInterface $filterQuery, $field, $values)

--- a/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
+++ b/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
@@ -6,6 +6,9 @@ use Doctrine\MongoDB\Query\Builder;
 use Doctrine\MongoDB\Query\Expr as MongoExpr;
 use Doctrine\ORM\Query\Expr as ORMExpr;
 use Doctrine\ORM\QueryBuilder;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CollectionAdapterFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderExecuterInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -33,10 +36,10 @@ class ItemEmbeddedOptionsFilterType extends AbstractType
             };
         }
 
-        $builder->add('name', 'filter_text');
-        $builder->add('position', 'filter_number');
-        $builder->add('options', 'filter_collection_adapter', array(
-            'type'       => new OptionFilterType(),
+        $builder->add('name', TextFilterType::class);
+        $builder->add('position', NumberFilterType::class);
+        $builder->add('options', CollectionAdapterFilterType::class, array(
+            'entry_type' => OptionFilterType::class,
             'add_shared' => $addShared,
         ));
     }
@@ -46,10 +49,5 @@ class ItemEmbeddedOptionsFilterType extends AbstractType
         $resolver->setDefaults(array(
             'doctrine_builder' => null,
         ));
-    }
-
-    public function getName()
-    {
-        return 'item_filter';
     }
 }

--- a/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
+++ b/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
@@ -6,10 +6,10 @@ use Doctrine\MongoDB\Query\Builder;
 use Doctrine\MongoDB\Query\Expr as MongoExpr;
 use Doctrine\ORM\Query\Expr as ORMExpr;
 use Doctrine\ORM\QueryBuilder;
+use Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderExecuterInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CollectionAdapterFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
-use Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderExecuterInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -49,5 +49,10 @@ class ItemEmbeddedOptionsFilterType extends AbstractType
         $resolver->setDefaults(array(
             'doctrine_builder' => null,
         ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'item_filter';
     }
 }

--- a/Tests/Fixtures/Filter/ItemFilterType.php
+++ b/Tests/Fixtures/Filter/ItemFilterType.php
@@ -5,13 +5,13 @@ namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\BooleanFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CheckboxFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateTimeFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
-use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 
 /**
  * Form filter for tests.
@@ -50,5 +50,10 @@ class ItemFilterType extends AbstractType
             'datetime'      => false,
             'disabled_name' => false,
         ));
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'item_filter';
     }
 }

--- a/Tests/Fixtures/Filter/ItemFilterType.php
+++ b/Tests/Fixtures/Filter/ItemFilterType.php
@@ -5,6 +5,12 @@ namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\BooleanFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\CheckboxFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateTimeFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 
 /**
@@ -17,23 +23,23 @@ class ItemFilterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         if (!$options['with_selector']) {
-            $builder->add('name', 'filter_text', array(
+            $builder->add('name', TextFilterType::class, array(
                 'apply_filter' => $options['disabled_name'] ? false : null,
             ));
-            $builder->add('position', 'filter_number', array(
+            $builder->add('position', NumberFilterType::class, array(
                 'condition_operator' => FilterOperands::OPERATOR_GREATER_THAN,
             ));
         } else {
-            $builder->add('name', 'filter_text', array(
+            $builder->add('name', TextFilterType::class, array(
                 'condition_pattern' => FilterOperands::OPERAND_SELECTOR,
             ));
-            $builder->add('position', 'filter_number', array(
+            $builder->add('position', NumberFilterType::class, array(
                 'condition_operator' => FilterOperands::OPERAND_SELECTOR,
             ));
         }
 
-        $builder->add('enabled', $options['checkbox'] ? 'filter_checkbox' : 'filter_boolean');
-        $builder->add('createdAt', $options['datetime'] ? 'filter_datetime' : 'filter_date');
+        $builder->add('enabled', $options['checkbox'] ? CheckboxFilterType::class : BooleanFilterType::class);
+        $builder->add('createdAt', $options['datetime'] ? DateTimeFilterType::class : DateFilterType::class);
     }
 
     public function configureOptions(OptionsResolver $resolver)
@@ -44,10 +50,5 @@ class ItemFilterType extends AbstractType
             'datetime'      => false,
             'disabled_name' => false,
         ));
-    }
-
-    public function getName()
-    {
-        return 'item_filter';
     }
 }

--- a/Tests/Fixtures/Filter/OptionFilterType.php
+++ b/Tests/Fixtures/Filter/OptionFilterType.php
@@ -4,6 +4,8 @@ namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 
 /**
  * Form filter for tests.
@@ -14,12 +16,7 @@ class OptionFilterType extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder->add('label', 'filter_text');
-        $builder->add('rank', 'filter_number');
-    }
-
-    public function getName()
-    {
-        return 'options_filter';
+        $builder->add('label', TextFilterType::class);
+        $builder->add('rank', NumberFilterType::class);
     }
 }

--- a/Tests/Fixtures/Filter/OptionFilterType.php
+++ b/Tests/Fixtures/Filter/OptionFilterType.php
@@ -19,4 +19,9 @@ class OptionFilterType extends AbstractType
         $builder->add('label', TextFilterType::class);
         $builder->add('rank', NumberFilterType::class);
     }
+
+    public function getBlockPrefix()
+    {
+        return 'options_filter';
+    }
 }

--- a/Tests/Fixtures/Filter/RangeFilterType.php
+++ b/Tests/Fixtures/Filter/RangeFilterType.php
@@ -5,6 +5,9 @@ namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateRangeFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\DateTimeRangeFilterType;
+use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberRangeFilterType;
 
 /**
  * Form filter for tests.
@@ -16,24 +19,24 @@ class RangeFilterType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
-            ->add('position', 'filter_number_range', array(
+            ->add('position', NumberRangeFilterType::class, array(
                 'left_number_options'  => array('condition_operator' => FilterOperands::OPERATOR_GREATER_THAN),
                 'right_number_options' => array('condition_operator' => FilterOperands::OPERATOR_LOWER_THAN),
             ))
-            ->add('position_selector', 'filter_number_range', array(
+            ->add('position_selector', NumberRangeFilterType::class, array(
                 'left_number_options'  => array('condition_operator' => FilterOperands::OPERAND_SELECTOR),
                 'right_number_options' => array('condition_operator' => FilterOperands::OPERAND_SELECTOR),
             ))
-            ->add('default_position', 'filter_number_range')
+            ->add('default_position', NumberRangeFilterType::class)
             ->add('createdAt', 'filter_date_range', array(
                 'left_date_options'  => array('widget' => 'single_text'),
                 'right_date_options' => array('widget' => 'choice'),
             ))
-            ->add('updatedAt', 'filter_datetime_range', array(
+            ->add('updatedAt', DateTimeRangeFilterType::class, array(
                 'left_datetime_options'  => array('date_widget' => 'single_text', 'time_widget' => 'single_text'),
                 'right_datetime_options' => array(),
             ))
-            ->add('startAt', 'filter_date_range', array(
+            ->add('startAt', DateRangeFilterType::class, array(
                 'left_date_options' => array(
                     'widget' => 'single_text',
                     'model_timezone' => 'UTC',
@@ -46,10 +49,5 @@ class RangeFilterType extends AbstractType
                 ),
             ))
         ;
-    }
-
-    public function getName()
-    {
-        return 'item_filter';
     }
 }

--- a/Tests/Fixtures/Filter/RangeFilterType.php
+++ b/Tests/Fixtures/Filter/RangeFilterType.php
@@ -50,4 +50,9 @@ class RangeFilterType extends AbstractType
             ))
         ;
     }
+
+    public function getBlockPrefix()
+    {
+        return 'item_filter';
+    }
 }

--- a/Tests/Fixtures/Filter/RangeFilterType.php
+++ b/Tests/Fixtures/Filter/RangeFilterType.php
@@ -28,7 +28,7 @@ class RangeFilterType extends AbstractType
                 'right_number_options' => array('condition_operator' => FilterOperands::OPERAND_SELECTOR),
             ))
             ->add('default_position', NumberRangeFilterType::class)
-            ->add('createdAt', 'filter_date_range', array(
+            ->add('createdAt', DateRangeFilterType::class, array(
                 'left_date_options'  => array('widget' => 'single_text'),
                 'right_date_options' => array('widget' => 'choice'),
             ))

--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.7",
-        "symfony/form": "~2.7",
+        "php": ">=5.5.0",
+        "symfony/framework-bundle": "~2.8",
+        "symfony/form": "~2.8",
         "doctrine/orm": "~2.2"
     },
     "require-dev": {


### PR DESCRIPTION
Some changes to prevent Symfony 2.8 from rising deprecated warnings and
3.0 from failing at all.

PHP7 fails for MongoDB due to the missing MongoDB extension. Doctrine with SQL works fine with PHP 7.0.

Addresses #187