### PR TITLE
Add optional encoding parameter for case insensitive text filtering

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -46,6 +46,11 @@ class Configuration implements ConfigurationInterface
                     ->info('Whether to do case insensitive LIKE comparisons.')
                     ->defaultNull()
                 ->end()
+
+                ->scalarNode('encoding')
+                    ->info('Encoding for case insensitive LIKE comparisons.')
+                    ->defaultNull()
+                ->end()
             ->end();
 
         return $treeBuilder;

--- a/DependencyInjection/LexikFormFilterExtension.php
+++ b/DependencyInjection/LexikFormFilterExtension.php
@@ -43,6 +43,14 @@ class LexikFormFilterExtension extends Extension
             );
         }
 
+        if (isset($config['encoding'])) {
+            $filterPrepareDef = $container->getDefinition('lexik_form_filter.filter_prepare');
+            $filterPrepareDef->addMethodCall(
+                'setEncoding',
+                array($config['encoding'])
+            );
+        }
+
         $container->setParameter('lexik_form_filter.where_method', $config['where_method']);
     }
 }

--- a/Event/Listener/PrepareListener.php
+++ b/Event/Listener/PrepareListener.php
@@ -16,6 +16,11 @@ class PrepareListener
     protected $forceCaseInsensitivity = null;
 
     /**
+     * @var string|null
+     */
+    protected $encoding;
+
+    /**
      * @param boolean $value
      * @return PrepareListener $this
      * @throws \InvalidArgumentException
@@ -51,6 +56,26 @@ class PrepareListener
     }
 
     /**
+     * @return null|string
+     */
+    public function getEncoding()
+    {
+        return $this->encoding;
+    }
+
+    /**
+     * @param null|string $encoding
+     *
+     * @return PrepareListener
+     */
+    public function setEncoding($encoding)
+    {
+        $this->encoding = $encoding;
+
+        return $this;
+    }
+
+    /**
      * Filter builder prepare event
      *
      * @param PrepareEvent $event
@@ -67,7 +92,7 @@ class PrepareListener
 
         foreach ($queryClasses as $builderClass => $queryClass) {
             if (class_exists($builderClass) && $qb instanceof $builderClass) {
-                $query = new $queryClass($qb, $this->getForceCaseInsensitivity($qb));
+                $query = new $queryClass($qb, $this->getForceCaseInsensitivity($qb), $this->encoding);
 
                 $event->setFilterQuery($query);
                 $event->stopPropagation();

--- a/Filter/Doctrine/Expression/DBALExpressionBuilder.php
+++ b/Filter/Doctrine/Expression/DBALExpressionBuilder.php
@@ -11,9 +11,9 @@ class DBALExpressionBuilder extends ExpressionBuilder
      *
      * @param Expr $expr
      */
-    public function __construct(Expr $expr, $forceCaseInsensitivity)
+    public function __construct(Expr $expr, $forceCaseInsensitivity, $encoding = null)
     {
         $this->expr = $expr;
-        parent::__construct($forceCaseInsensitivity);
+        parent::__construct($forceCaseInsensitivity, $encoding);
     }
 }

--- a/Filter/Doctrine/Expression/ExpressionBuilder.php
+++ b/Filter/Doctrine/Expression/ExpressionBuilder.php
@@ -20,6 +20,11 @@ abstract class ExpressionBuilder
     protected $forceCaseInsensitivity;
 
     /**
+     * @var string
+     */
+    protected $encoding;
+
+    /**
      * Get expression object.
      */
     public function expr()
@@ -29,10 +34,12 @@ abstract class ExpressionBuilder
 
     /**
      * @param boolean $forceCaseInsensitivity
+     * @param string|null $encoding
      */
-    public function __construct($forceCaseInsensitivity)
+    public function __construct($forceCaseInsensitivity, $encoding = null)
     {
         $this->forceCaseInsensitivity = $forceCaseInsensitivity;
+        $this->encoding = $encoding;
     }
 
     /**
@@ -219,7 +226,7 @@ abstract class ExpressionBuilder
     protected function convertTypeToMask($value, $type)
     {
         if ($this->forceCaseInsensitivity) {
-            $value = mb_strtolower($value);
+            $value = $this->encoding ? mb_strtolower($value, $this->encoding) : mb_strtolower($value);
         }
 
         switch ($type) {

--- a/Filter/Doctrine/Expression/ORMExpressionBuilder.php
+++ b/Filter/Doctrine/Expression/ORMExpressionBuilder.php
@@ -11,9 +11,9 @@ class ORMExpressionBuilder extends ExpressionBuilder
      *
      * @param Expr $expr
      */
-    public function __construct(Expr $expr, $forceCaseInsensitivity)
+    public function __construct(Expr $expr, $forceCaseInsensitivity, $encoding = null)
     {
         $this->expr = $expr;
-        parent::__construct($forceCaseInsensitivity);
+        parent::__construct($forceCaseInsensitivity, $encoding);
     }
 }

--- a/Filter/Doctrine/ORMQuery.php
+++ b/Filter/Doctrine/ORMQuery.php
@@ -27,13 +27,15 @@ class ORMQuery implements QueryInterface
      *
      * @param QueryBuilder $queryBuilder
      * @param boolean      $forceCaseInsensitivity
+     * @param string|null  $encoding
      */
-    public function __construct(QueryBuilder $queryBuilder, $forceCaseInsensitivity = false)
+    public function __construct(QueryBuilder $queryBuilder, $forceCaseInsensitivity = false, $encoding = null)
     {
         $this->queryBuilder      = $queryBuilder;
         $this->expressionBuilder = new ORMExpressionBuilder(
             $this->queryBuilder->expr(),
-            $forceCaseInsensitivity
+            $forceCaseInsensitivity,
+            $encoding
         );
     }
 


### PR DESCRIPTION
It helps to filter by text fields which contains non-latin symbols (i.e. cyrillic in UTF-8) 