### PR TITLE
Removed a deprecated call in BooleanFilterType

### DIFF
--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -45,7 +45,7 @@ class BooleanFilterType extends AbstractType
                     'boolean.no'  => self::VALUE_NO,
                 ),
                 'choices_as_values'      => true, // must be removed for use in Symfony 3.1, needed for 2.8
-                'empty_value'            => 'boolean.yes_or_no',
+                'placeholder'            => 'boolean.yes_or_no',
                 'translation_domain'     => 'LexikFormFilterBundle',
                 'data_extraction_method' => 'default',
             ))


### PR DESCRIPTION
'empty_value' option for Choice form types is deprecated in 2.8, so I removed it from BooleanFilterType.

See also #196 