### PR TITLE
Remove non-existent property $alias

### DIFF
--- a/Event/GetFilterConditionEvent.php
+++ b/Event/GetFilterConditionEvent.php
@@ -79,14 +79,6 @@ class GetFilterConditionEvent extends Event
     }
 
     /**
-     * @return mixed
-     */
-    public function getAlias()
-    {
-        return $this->alias;
-    }
-
-    /**
      * @param string $expression
      * @param array  $parameters
      */


### PR DESCRIPTION
There is no such property $alias in this event, but there is a getAlias function returning it.
This removes the function as it can't possibly work