### PR TITLE
Add "encoding" parameter in documentation

### DIFF
--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -40,6 +40,7 @@ If you want to avoid that, there is a configuration option:
 # app/config/config.yml
 lexik_form_filter:
     force_case_insensitivity: false
+    encoding: ~ # Encoding for case insensitive LIKE comparisons. For example: UTF-8
 ```
 
 If you use Postgres and you want your LIKE comparisons to be case sensitive


### PR DESCRIPTION
Add "lexik_form_filter.encoding" in configuration documentation.
This configuration parameter is really important when you want to use encoding different from default one (mbstring.internal_encoding).

https://github.com/lexik/LexikFormFilterBundle/blob/master/DependencyInjection/Configuration.php#L60