### PR TITLE
Use "Symfony" instead of "Symfony2"

### DIFF
--- a/Event/Subscriber/DoctrineDBALSubscriber.php
+++ b/Event/Subscriber/DoctrineDBALSubscriber.php
@@ -29,7 +29,7 @@ class DoctrineDBALSubscriber extends AbstractDoctrineSubscriber implements Event
             'lexik_form_filter.apply.dbal.filter_number_range'   => array('filterNumberRange'),
             'lexik_form_filter.apply.dbal.filter_text'           => array('filterText'),
 
-            // Symfony2 field types
+            // Symfony field types
             'lexik_form_filter.apply.dbal.text'     => array('filterText'),
             'lexik_form_filter.apply.dbal.email'    => array('filterValue'),
             'lexik_form_filter.apply.dbal.integer'  => array('filterValue'),

--- a/Event/Subscriber/DoctrineMongodbSubscriber.php
+++ b/Event/Subscriber/DoctrineMongodbSubscriber.php
@@ -34,7 +34,7 @@ class DoctrineMongodbSubscriber implements EventSubscriberInterface
             'lexik_form_filter.apply.mongodb.filter_text'           => array('filterText'),
             'lexik_form_filter.apply.mongodb.filter_document'       => array('filterDocument'),
 
-            // Symfony2 types
+            // Symfony types
             'lexik_form_filter.apply.mongodb.text'     => array('filterText'),
             'lexik_form_filter.apply.mongodb.email'    => array('filterValue'),
             'lexik_form_filter.apply.mongodb.integer'  => array('filterValue'),

--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -36,7 +36,7 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
             'lexik_form_filter.apply.orm.filter_number_range'   => array('filterNumberRange'),
             'lexik_form_filter.apply.orm.filter_text'           => array('filterText'),
 
-            // Symfony2 types
+            // Symfony types
             'lexik_form_filter.apply.orm.text'     => array('filterText'),
             'lexik_form_filter.apply.orm.email'    => array('filterValue'),
             'lexik_form_filter.apply.orm.integer'  => array('filterValue'),

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Overview
 ========
 
-This Symfony2 bundle aims to provide classes to build some form types dedicated to filter an entity.
+This Symfony bundle aims to provide classes to build some form types dedicated to filter an entity.
 Once you created your form type you will be able to update a doctrine query builder conditions from a form type.
 
 [![Build Status](https://travis-ci.org/lexik/LexikFormFilterBundle.png?branch=master)](https://travis-ci.org/lexik/LexikFormFilterBundle)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "lexik/form-filter-bundle",
     "type": "symfony-bundle",
     "description": "This bundle aim to provide classes to build some form filters and then build a doctrine query from this form filter.",
-    "keywords": ["Symfony2", "bundle", "form", "filter", "doctrine"],
+    "keywords": ["Symfony", "bundle", "form", "filter", "doctrine"],
     "homepage": "https://github.com/lexik/LexikFormFilterBundle",
     "license": "MIT",
     "minimum-stability": "dev",


### PR DESCRIPTION
Using "Symfony2" doesn't make much sense anymore. Please note that this should be changed also in repository description