### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ php:
     - 5.5
     - 5.6
     - 7.0
-    - hhvm
+    - 7.1
 
 matrix:
+    include:
+        - php: hhvm
+          dist: trusty
     fast_finish: true
     allow_failures:
         - php: hhvm


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.