### PR TITLE
Fix Symfony 4.2 deprecation

### DIFF
--- a/Filter/Form/FilterTypeExtension.php
+++ b/Filter/Form/FilterTypeExtension.php
@@ -41,10 +41,10 @@ class FilterTypeExtension extends AbstractTypeExtension
     }
 
     /**
-     * {@inheritdoc}
+     * @return iterable
      */
-    public function getExtendedType()
+    public static function getExtendedTypes()
     {
-        return FormType::class;
+        return [FormType::class];
     }
 }


### PR DESCRIPTION
Not implementing the static getExtendedTypes() method in FilterTypeExtension when implementing the Symfony\Component\Form\FormTypeExtensionInterface is deprecated since Symfony 4.2.