### PR TITLE
Revert "Revert "Replaced use of ltrim as it doesn't work as intended.""

### DIFF
--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -78,7 +78,7 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
 
             if ($dqlFrom = $event->getQueryBuilder()->getDQLPart('from')) {
                 $rootPart = reset($dqlFrom);
-                $fieldName = ltrim($event->getField(), $rootPart->getAlias() . '.');
+                $fieldName = preg_replace('/^'.$rootPart->getAlias().'\./', '', $event->getField());
                 $metadata = $queryBuilder->getEntityManager()->getClassMetadata($rootPart->getFrom());
 
                 if (isset($metadata->associationMappings[$fieldName]) && (!$metadata->associationMappings[$fieldName]['isOwningSide'] || $metadata->associationMappings[$fieldName]['type'] === ClassMetadataInfo::MANY_TO_MANY)) {


### PR DESCRIPTION
Reverts lexik/LexikFormFilterBundle#301
Now that the reason for the revert is gone(fixed date in tests) can we reapply this?