### PR TITLE
Symfony event contracts

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\FormFilterBundle\DependencyInjection;
 
-use Lexik\Bundle\FormFilterBundle\Filter\FilterOperands;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 

--- a/Event/ApplyFilterConditionEvent.php
+++ b/Event/ApplyFilterConditionEvent.php
@@ -3,7 +3,6 @@
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilderInterface;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Event class to compute the WHERE clause from the conditions.

--- a/Event/Event.php
+++ b/Event/Event.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Lexik\Bundle\FormFilterBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+
+if (\class_exists(ContractsEvent::class)) {
+    abstract class Event extends ContractsEvent
+    {
+    }
+} else {
+    abstract class Event extends LegacyEvent
+    {
+    }
+}

--- a/Event/GetFilterConditionEvent.php
+++ b/Event/GetFilterConditionEvent.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\Condition;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;

--- a/Event/PrepareEvent.php
+++ b/Event/PrepareEvent.php
@@ -2,7 +2,6 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 
 /**

--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -6,6 +6,7 @@ use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilder;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilderInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
@@ -85,7 +86,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
     {
         // create the right QueryInterface object
         $event = new PrepareEvent($queryBuilder);
-        $this->dispatcher->dispatch(FilterEvents::PREPARE, $event);
+        $this->dispatch(FilterEvents::PREPARE, $event);
 
         if (!$event->getFilterQuery() instanceof QueryInterface) {
             throw new \RuntimeException("Couldn't find any filter query object.");
@@ -103,7 +104,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
 
         // walk condition nodes to add condition on the query builder instance
         $name = sprintf('lexik_filter.apply_filters.%s', $event->getFilterQuery()->getEventPartName());
-        $this->dispatcher->dispatch($name, new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder));
+        $this->dispatch($name, new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder));
 
         $this->conditionBuilder = null;
 
@@ -207,7 +208,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
             }
 
             $event = new GetFilterConditionEvent($filterQuery, $field, $values);
-            $this->dispatcher->dispatch($eventName, $event);
+            $this->dispatch($eventName, $event);
 
             $condition = $event->getCondition();
         }
@@ -286,6 +287,21 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
             } else {
                 $root->field($name);
             }
+        }
+    }
+
+    /**
+     * @param string|object $eventName
+     * @param string|object $event
+     *
+     * @return mixed
+     */
+    protected function dispatch($eventName, $event)
+    {
+        if ($event instanceof ContractsEvent) {
+            return $this->dispatcher->dispatch($event, $eventName);
+        } else {
+            return $this->dispatcher->dispatch($eventName, $event);
         }
     }
 }


### PR DESCRIPTION
Adds some bridgework to enable direct use of both the new and old Symfony Event Dispatchers without bubbling up exceptions about using the old event dispatcher.