### PR TITLE
Fix symfony dispatch deprecation

### DIFF
--- a/Event/ApplyFilterConditionEvent.php
+++ b/Event/ApplyFilterConditionEvent.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilderInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event class to compute the WHERE clause from the conditions.

--- a/Event/GetFilterConditionEvent.php
+++ b/Event/GetFilterConditionEvent.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\Condition;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;

--- a/Event/PrepareEvent.php
+++ b/Event/PrepareEvent.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 
 /**

--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -85,7 +85,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
     {
         // create the right QueryInterface object
         $event = new PrepareEvent($queryBuilder);
-        $this->dispatcher->dispatch(FilterEvents::PREPARE, $event);
+        $this->dispatcher->dispatch($event, FilterEvents::PREPARE);
 
         if (!$event->getFilterQuery() instanceof QueryInterface) {
             throw new \RuntimeException("Couldn't find any filter query object.");
@@ -103,7 +103,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
 
         // walk condition nodes to add condition on the query builder instance
         $name = sprintf('lexik_filter.apply_filters.%s', $event->getFilterQuery()->getEventPartName());
-        $this->dispatcher->dispatch($name, new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder));
+        $this->dispatcher->dispatch(new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder), $name);
 
         $this->conditionBuilder = null;
 
@@ -207,7 +207,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
             }
 
             $event = new GetFilterConditionEvent($filterQuery, $field, $values);
-            $this->dispatcher->dispatch($eventName, $event);
+            $this->dispatcher->dispatch($event, $eventName);
 
             $condition = $event->getCondition();
         }


### PR DESCRIPTION
In SF4.3 and higher, dispatch method receive the name as second argument.