### PR TITLE
Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 5.6
+        - php: 7.1
           env: SYMFONY_VERSION=3.4.*
         - php: 7.3
           env: SYMFONY_VERSION=4.3.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,10 @@
 language: php
 
+dist: trusty
+
 cache:
     directories:
         - $HOME/.composer/cache/files
-
-php:
-    - 7.0
-    - 7.1
-    - 7.2
-    - 7.3
 
 env:
     global:
@@ -16,12 +12,16 @@ env:
         - COMPOSER_FLAGS=""
 
 matrix:
+    fast_finish: true
     include:
         - php: 5.6
-          env: MONGO_EXTENSION="mongo.so" SYMFONY_VERSION="symfony/lts:^2"
-        - php: 7.1
-          env: SYMFONY_VERSION="symfony/lts:^3"
-    fast_finish: true
+          env: SYMFONY_VERSION=3.4.*
+        - php: 7.3
+          env: SYMFONY_VERSION=4.3.*
+        - php: 7.3
+          env: SYMFONY_VERSION=4.4.*
+        - php: 7.3
+          env: SYMFONY_VERSION=5.0.*
 
 services:
     - mongodb
@@ -33,10 +33,10 @@ before_install:
 
 before_script:
     - composer config platform.ext-mongo 1.6.16
-    - if [ "$SYMFONY_VERSION" != "" ]; then travis_wait composer require --no-update $SYMFONY_VERSION; fi;
-    - travis_wait composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
-    - if ! [[ $TRAVIS_PHP_VERSION =~ ^5 ]]; then composer require alcaeus/mongo-php-adapter; fi;
+    - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
+    - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
+    - if ! [[ $TRAVIS_PHP_VERSION =~ ^5 ]]; then composer require alcaeus/mongo-php-adapter --no-update; fi;
 
-script:
-    - composer validate --no-check-lock --strict
-    - bin/phpunit --coverage-text
+install: composer update --no-interaction
+
+script: composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
 matrix:
     fast_finish: true
     include:
-        - php: 7.1
-          env: SYMFONY_VERSION=3.4.*
         - php: 7.3
           env: SYMFONY_VERSION=4.3.*
         - php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,6 @@ before_install:
     - echo "extension = $MONGO_EXTENSION" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - echo 'date.timezone = "Europe/Paris"' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
     - echo 'memory_limit = -1' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
-before_script:
     - composer config platform.ext-mongo 1.6.16
     - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
     - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;

--- a/Event/ApplyFilterConditionEvent.php
+++ b/Event/ApplyFilterConditionEvent.php
@@ -3,7 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilderInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Event class to compute the WHERE clause from the conditions.

--- a/Event/GetFilterConditionEvent.php
+++ b/Event/GetFilterConditionEvent.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\Condition;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;

--- a/Event/Listener/DoctrineMongoDBApplyFilterListener.php
+++ b/Event/Listener/DoctrineMongoDBApplyFilterListener.php
@@ -2,8 +2,8 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event\Listener;
 
-use Doctrine\MongoDB\Query\Builder;
-use Doctrine\MongoDB\Query\Expr;
+use Doctrine\ODM\MongoDB\Query\Builder;
+use Doctrine\ODM\MongoDB\Query\Expr;
 use Lexik\Bundle\FormFilterBundle\Event\ApplyFilterConditionEvent;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionNodeInterface;

--- a/Event/PrepareEvent.php
+++ b/Event/PrepareEvent.php
@@ -2,7 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 
 /**

--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -5,8 +5,7 @@ namespace Lexik\Bundle\FormFilterBundle\Filter;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilder;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionBuilderInterface;
 use Lexik\Bundle\FormFilterBundle\Filter\Condition\ConditionInterface;
@@ -87,11 +86,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
         // create the right QueryInterface object
         $event = new PrepareEvent($queryBuilder);
 
-        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-            $this->dispatcher->dispatch($event, FilterEvents::PREPARE);
-        } else {
-            $this->dispatcher->dispatch(FilterEvents::PREPARE, $event);
-        }
+        $this->dispatcher->dispatch($event, FilterEvents::PREPARE);
 
         if (!$event->getFilterQuery() instanceof QueryInterface) {
             throw new \RuntimeException("Couldn't find any filter query object.");
@@ -110,11 +105,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
         // walk condition nodes to add condition on the query builder instance
         $name = sprintf('lexik_filter.apply_filters.%s', $event->getFilterQuery()->getEventPartName());
 
-        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-            $this->dispatcher->dispatch(new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder), $name);
-        } else {
-            $this->dispatcher->dispatch($name, new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder));
-        }
+        $this->dispatcher->dispatch(new ApplyFilterConditionEvent($queryBuilder, $this->conditionBuilder), $name);
 
         $this->conditionBuilder = null;
 
@@ -219,11 +210,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
 
             $event = new GetFilterConditionEvent($filterQuery, $field, $values);
 
-            if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
-                $this->dispatcher->dispatch($event, $eventName);
-            } else {
-                $this->dispatcher->dispatch($eventName, $event);
-            }
+            $this->dispatcher->dispatch($event, $eventName);
 
             $condition = $event->getCondition();
         }

--- a/Filter/Form/FilterTypeExtension.php
+++ b/Filter/Form/FilterTypeExtension.php
@@ -51,7 +51,7 @@ class FilterTypeExtension extends AbstractTypeExtension
     /**
      * @return iterable
      */
-    public static function getExtendedTypes()
+    public static function getExtendedTypes(): iterable
     {
         return [FormType::class];
     }

--- a/Tests/Fixtures/Document/Item.php
+++ b/Tests/Fixtures/Document/Item.php
@@ -42,7 +42,7 @@ class Item
     protected $updatedAt;
 
     /**
-     * @Mongo\EmbedMany(targetDocument="Options", strategy="set")
+     * @Mongo\EmbedMany(targetDocument="Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Document\Options", strategy="set")
      */
     protected $options;
 

--- a/Tests/Fixtures/Filter/FormType.php
+++ b/Tests/Fixtures/Filter/FormType.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
+use Doctrine\ODM\MongoDB\Query\Expr;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -21,7 +22,7 @@ class FormType extends AbstractType
         $builder->add('position', IntegerType::class, array(
             'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                 if (!empty($values['value'])) {
-                    if ($filterQuery->getExpr() instanceof \Doctrine\MongoDB\Query\Expr) {
+                    if ($filterQuery->getExpr() instanceof Expr) {
                         $expr = $filterQuery->getExpr()->field($field)->equals($values['value']);
                     } else {
                         $expr = $filterQuery->getExpr()->eq($field, $values['value']);

--- a/Tests/Fixtures/Filter/ItemCallbackFilterType.php
+++ b/Tests/Fixtures/Filter/ItemCallbackFilterType.php
@@ -2,6 +2,7 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
+use Doctrine\ODM\MongoDB\Query\Expr;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\NumberFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Form\Type\TextFilterType;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
@@ -23,7 +24,7 @@ class ItemCallbackFilterType extends AbstractType
         $builder->add('position', NumberFilterType::class, array(
             'apply_filter' => function (QueryInterface $filterQuery, $field, $values) {
                 if (!empty($values['value'])) {
-                    if ($filterQuery->getExpr() instanceof \Doctrine\MongoDB\Query\Expr) {
+                    if ($filterQuery->getExpr() instanceof Expr) {
                         $expr = $filterQuery->getExpr()->field($field)->notEqual($values['value']);
                     } else {
                         $expr = $filterQuery->getExpr()->neq($field, $values['value']);
@@ -45,7 +46,7 @@ class ItemCallbackFilterType extends AbstractType
     public function fieldNameCallback(QueryInterface $filterQuery, $field, $values)
     {
         if (!empty($values['value'])) {
-            if ($filterQuery->getExpr() instanceof \Doctrine\MongoDB\Query\Expr) {
+            if ($filterQuery->getExpr() instanceof Expr) {
                 $expr = $filterQuery->getExpr()->field($field)->notEqual($values['value']);
             } else {
                 $expr = $filterQuery->getExpr()->neq($field, sprintf('\'%s\'', $values['value']));

--- a/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
+++ b/Tests/Fixtures/Filter/ItemEmbeddedOptionsFilterType.php
@@ -2,8 +2,6 @@
 
 namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
-use Doctrine\MongoDB\Query\Builder;
-use Doctrine\MongoDB\Query\Expr as MongoExpr;
 use Doctrine\ORM\Query\Expr as ORMExpr;
 use Doctrine\ORM\QueryBuilder;
 use Lexik\Bundle\FormFilterBundle\Filter\FilterBuilderExecuterInterface;

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,7 @@
         "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/orm": "^2.4.8",
         "symfony/form": "^3.4|^4.0|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.5.00",
-        "symfony/symfony": "4.4.*"
+        "symfony/framework-bundle": "^3.4|^4.0|^5.5.00"
     },
     "require-dev": {
         "doctrine/mongodb-odm-bundle": "^3.0|^4.0",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "keywords": ["Symfony", "bundle", "form", "filter", "doctrine"],
     "homepage": "https://github.com/lexik/LexikFormFilterBundle",
     "license": "MIT",
-    "minimum-stability": "dev",
     "prefer-stable": true,
     "authors": [
         {
@@ -20,13 +19,12 @@
     "require": {
         "php": ">=5.5.9",
         "doctrine/doctrine-bundle": "^1.12|^2.0",
-        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/orm": "^2.4.8",
         "symfony/form": "^3.4|^4.0|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.5.00"
+        "symfony/framework-bundle": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
-        "doctrine/mongodb-odm-bundle": "^3.0|^4.0",
+        "doctrine/mongodb-odm-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0"
     },
@@ -34,10 +32,7 @@
         "psr-4": { "Lexik\\Bundle\\FormFilterBundle\\": "" }
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "ext-mongo": "1.6.16"
-        }
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -17,17 +17,17 @@
         }
     ],
     "require": {
-        "php": ">=5.5.9",
-        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "php": ">=7.0",
         "doctrine/orm": "^2.4.8",
-        "symfony/form": "^3.4|^4.0|^5.0",
-        "symfony/framework-bundle": "^3.4|^4.0|^5.0"
+        "symfony/form": "^4.0|^5.0",
+        "symfony/framework-bundle": "^4.0|^5.0",
+        "symfony/symfony": "4.3.*"
     },
     "require-dev": {
-        "doctrine/mongodb-odm": "^1.1|^2.0",
-        "doctrine/mongodb-odm-bundle": "^3.0",
-        "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
-        "symfony/var-dumper": "^3.4|^4.0|^5.0"
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
+        "doctrine/mongodb-odm-bundle": "^4.1",
+        "symfony/phpunit-bridge": "^4.0|^5.0",
+        "symfony/var-dumper": "^4.0|^5.0"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\FormFilterBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
         "php": ">=7.0",
         "doctrine/orm": "^2.4.8",
         "symfony/form": "^4.0|^5.0",
-        "symfony/framework-bundle": "^4.0|^5.0",
-        "symfony/symfony": "4.3.*"
+        "symfony/framework-bundle": "^4.0|^5.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,20 +19,26 @@
     ],
     "require": {
         "php": ">=5.5.9",
+        "doctrine/doctrine-bundle": "^1.12|^2.0",
+        "alcaeus/mongo-php-adapter": "^1.1",
         "doctrine/orm": "^2.4.8",
-        "symfony/framework-bundle": "~2.8|~3.0|^4.0",
-        "symfony/form": "~2.8|~3.0|^4.0"
+        "symfony/form": "^3.4|^4.0|^5.0",
+        "symfony/framework-bundle": "^3.4|^4.0|^5.5.00",
+        "symfony/symfony": "4.4.*"
     },
     "require-dev": {
-        "doctrine/mongodb-odm-bundle": "^3.0",
-        "phpunit/phpunit": "~5.0|^7.5"
+        "doctrine/mongodb-odm-bundle": "^3.0|^4.0",
+        "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
+        "symfony/var-dumper": "^3.4|^4.0|^5.0"
     },
     "autoload":     {
         "psr-4": { "Lexik\\Bundle\\FormFilterBundle\\": "" }
     },
     "config": {
-        "bin-dir": "bin",
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "ext-mongo": "1.6.16"
+        }
     },
     "extra": {
         "branch-alias": {
@@ -41,5 +47,10 @@
     },
     "suggest": {
         "alcaeus/mongo-php-adapter": "Install this package if using the PHP 7 MongoDB Driver"
+    },
+    "scripts": {
+        "test": [
+            "vendor/bin/simple-phpunit"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,13 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "doctrine/doctrine-bundle": "^1.12|^2.0",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/orm": "^2.4.8",
         "symfony/form": "^3.4|^4.0|^5.0",
         "symfony/framework-bundle": "^3.4|^4.0|^5.0"
     },
     "require-dev": {
+        "doctrine/mongodb-odm": "^1.1|^2.0",
         "doctrine/mongodb-odm-bundle": "^3.0",
         "symfony/phpunit-bridge": "^3.4|^4.0|^5.0",
         "symfony/var-dumper": "^3.4|^4.0|^5.0"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,7 +29,6 @@
 
     <php>
         <server name="SYMFONY_PHPUNIT_VERSION" value="7.5"/>
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
 
     <listeners>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
-         backupGlobals="false"
+<phpunit backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -11,7 +8,7 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         bootstrap="Tests/bootstrap.php"
+         bootstrap="vendor/autoload.php"
 >
     <testsuites>
         <testsuite name="LexikFormFilterBundle Test Suite">
@@ -25,11 +22,12 @@
             <exclude>
                 <directory>./Resources</directory>
                 <directory>./Tests</directory>
+                <directory>./vendor</directory>
             </exclude>
         </whitelist>
     </filter>
 
     <php>
-        <server name="ROOT_DIR" value="../../../../.." />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="7.5"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,14 +2,14 @@
 
 <phpunit backupGlobals="false"
          backupStaticAttributes="false"
-         colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
->
+    >
+
     <testsuites>
         <testsuite name="LexikFormFilterBundle Test Suite">
             <directory>./Tests/</directory>
@@ -29,5 +29,10 @@
 
     <php>
         <server name="SYMFONY_PHPUNIT_VERSION" value="7.5"/>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled" />
     </php>
+
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>


### PR DESCRIPTION
@garak 

I created a new PR and made some little changes in travis.yml and TestCase.
I remove tests for SF 2.8 because we need to require doctrine/doctrine-bundle but this bundle required SF 3.4...
And I looked at the other bundles a bit, and kept the master branch compatible with 2.8 is no longer really a relevant thing.

But composer failed with SF 5.0 and `doctrine/mongodb-odm-bundle` if you have an idea?

- [x] sf 3.4 removing
- [x] sf 4.3
- [x] sf 4.4 
- [x] sf 5.0