### PR TITLE
Add filter_shared_name option to override join name

### DIFF
--- a/Filter/FilterBuilderUpdater.php
+++ b/Filter/FilterBuilderUpdater.php
@@ -129,7 +129,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
 
             // this means we have a relation
             if ($child->getConfig()->hasAttribute('add_shared')) {
-                $join = trim($alias . '.' . $child->getName(), '.');
+                $join = $child->getConfig()->getAttribute('filter_shared_name') ?? trim($alias . '.' . $child->getName(), '.');
 
                 $addSharedClosure = $child->getConfig()->getAttribute('add_shared');
 
@@ -150,7 +150,7 @@ class FilterBuilderUpdater implements FilterBuilderUpdaterInterface
 
             // Doctrine2 embedded object case
             } elseif ($formType instanceof EmbeddedFilterTypeInterface) {
-                $this->addFilters($child, $filterQuery, $alias . '.' . $child->getName());
+                $this->addFilters($child, $filterQuery, $child->getConfig()->getAttribute('filter_field_name') ?? ($alias . '.' . $child->getName()));
 
             // default case
             } else {

--- a/Filter/Form/FilterTypeExtension.php
+++ b/Filter/Form/FilterTypeExtension.php
@@ -30,6 +30,10 @@ class FilterTypeExtension extends AbstractTypeExtension
         if (null !== $options['filter_field_name']) {
             $builder->setAttribute('filter_field_name', $options['filter_field_name']);
         }
+
+        if (null !== $options['filter_shared_name']) {
+            $builder->setAttribute('filter_shared_name', $options['filter_shared_name']);
+        }
     }
 
     /**
@@ -42,6 +46,7 @@ class FilterTypeExtension extends AbstractTypeExtension
             'data_extraction_method'   => 'default',
             'filter_condition_builder' => null,
             'filter_field_name'        => null,
+            'filter_shared_name'       => null,
         ));
     }
 

--- a/Resources/doc/filtertypeextension.md
+++ b/Resources/doc/filtertypeextension.md
@@ -144,6 +144,10 @@ See [4.iii section](working-with-the-bundle.md#iii-customize-condition-operator)
 
 This option is used to define the field name on which the condition is applied.
 
+##### The `filter_shared_name` option:
+
+This option is used to define the shared join name on which the condition is applied.
+
 ***
 
 Next: [7. Working with other bundles](working-with-other-bundles.md)


### PR DESCRIPTION
Hi, I added a `filter_shared_name` option to override the shared join name