### PR TITLE
Translate choices and use an empty choice as default

### DIFF
--- a/Filter/Form/Type/BooleanFilterType.php
+++ b/Filter/Form/Type/BooleanFilterType.php
@@ -42,11 +42,11 @@ class BooleanFilterType extends AbstractType
             ->setDefaults(array(
                 'required'               => false,
                 'choices'                => array(
+                    'boolean.yes_or_no' => '',
                     'boolean.yes' => self::VALUE_YES,
                     'boolean.no'  => self::VALUE_NO,
                 ),
-                'placeholder'            => 'boolean.yes_or_no',
-                'translation_domain'     => 'LexikFormFilterBundle',
+                'choice_translation_domain' => 'LexikFormFilterBundle',
                 'data_extraction_method' => 'default',
             ))
             ->setAllowedValues('data_extraction_method', array('default'))


### PR DESCRIPTION
By default types have the default translation domain in this bundle,
which is good, because I want to translate the labels in user-land, but
the boolean type sets a different domain, so my label will be
translated in that domain instead. This fixes the issue and only
translates the choices in the bundles domain.
