### PR TITLE
Remove deprecation notice in PHP 8.1

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,18 +18,9 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritDoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
-        $treeBuilder = new TreeBuilder('lexik_form_filter');
-
-        if (\method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->getRootNode();
-        } else {
-            // BC layer for symfony/config 4.1 and older
-            $rootNode = $treeBuilder->root('lexik_form_filter');
-        }
-
-        $rootNode
+        return (new TreeBuilder('lexik_form_filter'))->getRootNode()
             ->children()
                 ->arrayNode('listeners')
                     ->addDefaultsIfNotSet()
@@ -67,8 +58,7 @@ class Configuration implements ConfigurationInterface
                     ->info('Encoding for case insensitive LIKE comparisons.')
                     ->defaultNull()
                 ->end()
-            ->end();
-
-        return $treeBuilder;
+            ->end()
+        ->end();
     }
 }


### PR DESCRIPTION
Adds a `TreeBuilder` return type to `Lexik\Bundle\FormFilterBundle\DependencyInjection\Configuration::getConfigTreeBuilder()` to remove a deprecation notice triggered by the missing return type in PHP 8.1. That does not conflict with older PHP versions, since at least PHP 7.1 is required in composer.json for the bundle.

Also tidies up the "BC layer for symfony/config 4.1 and older" from that method as in composer.json at least Symfony 4.4 is required for the bundle and the BC layer is not needed anymore.