### PR TITLE
Fix ltrim

### DIFF
--- a/Event/Subscriber/DoctrineORMSubscriber.php
+++ b/Event/Subscriber/DoctrineORMSubscriber.php
@@ -78,7 +78,10 @@ class DoctrineORMSubscriber extends AbstractDoctrineSubscriber implements EventS
 
             if ($dqlFrom = $event->getQueryBuilder()->getDQLPart('from')) {
                 $rootPart = reset($dqlFrom);
-                $fieldName = ltrim($event->getField(), $rootPart->getAlias() . '.');
+                $fieldName = $event->getField();
+                if (0 === strpos($fieldName, $rootPart->getAlias() . '.')) {
+                    $fieldName = substr($fieldName, strlen($rootPart->getAlias() . '.'));
+                }
                 $metadata = $queryBuilder->getEntityManager()->getClassMetadata($rootPart->getFrom());
 
                 if (isset($metadata->associationMappings[$fieldName]) && (!$metadata->associationMappings[$fieldName]['isOwningSide'] || $metadata->associationMappings[$fieldName]['type'] === ClassMetadataInfo::MANY_TO_MANY)) {


### PR DESCRIPTION
The ltrim function accepts a list of characters, so any other characters after `.` that matches given list could be removed.