### PR TITLE
Translations: Fix french translation for lower_than_equal

### DIFF
--- a/Resources/translations/LexikFormFilterBundle.fr.yml
+++ b/Resources/translations/LexikFormFilterBundle.fr.yml
@@ -8,7 +8,7 @@ number:
     greater_than:       "Plus grand que"
     greater_than_equal: "Plus grand ou égal à"
     lower_than:         "Plus petit que"
-    lower_than_equal:   "Plus petit ou égale à"
+    lower_than_equal:   "Plus petit ou égal à"
 
 text:
     starts:             "Commence par"


### PR DESCRIPTION
Fix typo in french for lower_than_equal  translation:
Use  _"Plus petit ou égal à"_ instead of  _"Plus petit ou égale à"_