### PR TITLE
Fixes BadRequestHttpException when following the documentation

### DIFF
--- a/Resources/doc/basics.md
+++ b/Resources/doc/basics.md
@@ -92,7 +92,7 @@ class DefaultController extends Controller
 
         if ($request->query->has($form->getName())) {
             // manually bind values from the request
-            $form->submit($request->query->get($form->getName()));
+            $form->submit($request->query->all($form->getName()));
 
             // initialize a query builder
             $filterBuilder = $this->get('doctrine.orm.entity_manager')

--- a/Resources/doc/working-with-other-bundles.md
+++ b/Resources/doc/working-with-other-bundles.md
@@ -28,7 +28,7 @@ class DefaultController extends Controller
 
         if ($request->query->has($form->getName())) {
             // manually bind values from the request
-            $form->submit($request->query->get($form->getName()));
+            $form->submit($request->query->all($form->getName()));
 
             // build the query from the given form object
             $this->get('lexik_form_filter.query_builder_updater')->addFilterConditions($form, $filterBuilder);


### PR DESCRIPTION
Hi,

I was trying to use this bundle with Symfony 6 but ended up with an error as soon as form filters were submitted.

```
Symfony\Component\HttpKernel\Exception\BadRequestHttpException: Input value "item_filter" contains a non-scalar value.
```

Following the documentation, I found out the issue came from this line.

```
// manually bind values from the request
$form->submit($request->query->get($form->getName()));
```

Since Symfony passed version 6, retrieving non-scalar values using InputBag::get() will throw a BadRequestException. (See [changelog here](https://github.com/symfony/symfony/blob/6.1/src/Symfony/Component/HttpFoundation/CHANGELOG.md#60))


From the http foundation package documentation:

```
// don't use $request->query->get('foo'); use the following instead:
$request->query->all()['foo'];
// returns ['bar' => 'baz']
```

So this PR fixes the documentation accordingly.