### PR TITLE
feat: improve ci, add more tests, fix deprecations, drop support of php 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    name: PHP v${{ matrix.php }}, Symfony v${{ matrix.symfony }}} with Mongo v${{ matrix.mongodb }}
+    name: PHP v${{ matrix.php }}, Symfony v${{ matrix.symfony }} with Mongo v${{ matrix.mongodb }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { php: 7.2, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-lowest'}
           - { php: 7.2, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.3, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.4, mongodb: 3.6, symfony: "5.4.*", composer-flags: '--prefer-stable'}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { php: 7.1, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-lowest'}
+          - { php: 7.2, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.3, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.4, mongodb: 3.6, symfony: "5.4.*", composer-flags: '--prefer-stable'}
           - { php: 8.0, mongodb: 3.6, symfony: "5.4.*", composer-flags: '--prefer-stable'}
           - { php: 8.0, mongodb: 3.6, symfony: "6.0.*", composer-flags: '--prefer-stable'}
-          - { php: 8.1, mongodb: 3.6, symfony: "6.1.*@dev", composer-flags: '' }
+          - { php: 8.1, mongodb: 3.6, symfony: "6.0.*", composer-flags: '--prefer-stable'}
+          - { php: 8.2, mongodb: 3.6, symfony: "6.2.*", composer-flags: '--prefer-stable'}
+          - { php: 8.2, mongodb: 3.6, symfony: "6.3.*@dev", composer-flags: '' }
     services:
       mongo:
         image: mongo:${{ matrix.mongodb }}
@@ -29,7 +33,7 @@ jobs:
           - 27017:27017
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: "Installing php"
         uses: shivammathur/setup-php@v2
         with:
@@ -44,14 +48,14 @@ jobs:
         
       - name: Download Composer cache dependencies from cache
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
       
       - name: "Require symfony/messenger"
         run: "composer require --dev symfony/doctrine-messenger --no-update"
-        if: "${{ startsWith(matrix.symfony, '5.3') || startsWith(matrix.symfony, '5.4') }}"
+        if: "${{ startsWith(matrix.symfony, '5.4') }}"
         
       - name: Cache Composer dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ matrix.os }}-composer-${{ hashFiles('**/composer.json') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { php: 7.1, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-lowest'}
+          - { php: 7.2, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-lowest'}
           - { php: 7.2, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.3, mongodb: 3.6, symfony: "4.4.*", composer-flags: '--prefer-stable'}
           - { php: 7.4, mongodb: 3.6, symfony: "5.4.*", composer-flags: '--prefer-stable'}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": ">=7.1",
+        "php": ">=7.2.5",
         "doctrine/orm": "^2.10",
         "symfony/form": "^4.4|^5.1|^6.0",
         "symfony/framework-bundle": "^4.4|^5.1|^6.0"


### PR DESCRIPTION
For drop of support for php 7.1, see https://github.com/Chris53897/LexikFormFilterBundle/actions/runs/4033220613/jobs/6933597204

Ci deprecation: please see https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Symfony 4.4 is no longer LTS https://symfony.com/releases/4.4
Maybe the support in this bundle could be droped?