### PR TITLE
fix: allow array values for expression parameters

### DIFF
--- a/Filter/Condition/Condition.php
+++ b/Filter/Condition/Condition.php
@@ -20,11 +20,12 @@ class Condition implements ConditionInterface
     private $expression;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      *
      * array(
      *     'param_name_1' => $value,
-     *     'param_nema_2  => array($value, $type),
+     *     'param_name_2  => ExpressionParameterValue($value, $type = null),
+     *     'param_name_3  => array($value, $type), // can be deprecated, as it interferes with array values (link for IN() expressions)
      * )
      */
     private $parameters;

--- a/Filter/Doctrine/Expression/ExpressionParameterValue.php
+++ b/Filter/Doctrine/Expression/ExpressionParameterValue.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+namespace Lexik\Bundle\FormFilterBundle\Filter\Doctrine\Expression;
+
+/**
+ * Holds the value and optionally the type of an expression parameter
+ * used to distinguish an array of values from the former array holding a single value and a type string
+ *
+ * @author Gregor Meyer https://github.com/spackmat
+ */
+final class ExpressionParameterValue
+{
+    /**
+     * should be a public readonly mixed promoted property when PHP level is raised to PHP 8.1
+     * @var mixed
+     */
+    public $value;
+
+    /**
+     * should be a public readonly ?string promoted property when PHP level is raised to PHP 8.1
+     * @var ?string $type
+     */
+    public $type;
+
+    public function __construct($value, ?string $type = null)
+    {
+        $this->value = $value;
+        $this->type = $type;
+    }
+}

--- a/Tests/Fixtures/Filter/FormType.php
+++ b/Tests/Fixtures/Filter/FormType.php
@@ -3,6 +3,7 @@
 namespace Lexik\Bundle\FormFilterBundle\Tests\Fixtures\Filter;
 
 use Doctrine\ODM\MongoDB\Query\Expr;
+use Lexik\Bundle\FormFilterBundle\Filter\Doctrine\Expression\ExpressionParameterValue;
 use Lexik\Bundle\FormFilterBundle\Filter\Query\QueryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -24,11 +25,12 @@ class FormType extends AbstractType
                 if (!empty($values['value'])) {
                     if ($filterQuery->getExpr() instanceof Expr) {
                         $expr = $filterQuery->getExpr()->field($field)->equals($values['value']);
-                    } else {
-                        $expr = $filterQuery->getExpr()->eq($field, $values['value']);
+                        return $filterQuery->createCondition($expr);
                     }
-
-                    return $filterQuery->createCondition($expr);
+                    return $filterQuery->createCondition(
+                        $filterQuery->getExpr()->eq($field, ':position'),
+                        ['position' => new ExpressionParameterValue($values['value'])]
+                    );
                 }
 
                 return null;


### PR DESCRIPTION
Fixes the problem described in https://github.com/lexik/LexikFormFilterBundle/issues/364 where array values for parameters of filter expressions are misinterpreted as [value, type] pairs, throwing strange errors within Doctrine.

When the value (with an optional type) is wrapped inside a `ExpressionParameterValue` value object, the `DoctrineApplyFilterListener` detects and used that explicit declaration. When the value is an array, it is checked if it contains a valid DBAL-type string on the second element, before it is assumed that it contains an implicit type decleration in that old array form. That branch can be deprecated in favor of the explicit declaration using the new `ExpressionParameterValue` class.